### PR TITLE
feat(mediator:119): add support for command return types (#119)

### DIFF
--- a/src/Cortex.Mediator/Behaviors/LoggingQueryBehavior.cs
+++ b/src/Cortex.Mediator/Behaviors/LoggingQueryBehavior.cs
@@ -1,4 +1,4 @@
-﻿using Cortex.Mediator.Commands;
+﻿using Cortex.Mediator.Queries;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics;
@@ -10,23 +10,23 @@ namespace Cortex.Mediator.Behaviors
     /// <summary>
     /// Pipeline behavior for logging command/query execution.
     /// </summary>
-    public sealed class LoggingCommandBehavior<TCommand, TResult> : ICommandPipelineBehavior<TCommand, TResult>
-        where TCommand : ICommand<TResult>
+    public sealed class LoggingQueryBehavior<TQuery, TResult> : IQueryPipelineBehavior<TQuery, TResult>
+        where TQuery : IQuery<TResult>
     {
-        private readonly ILogger<LoggingCommandBehavior<TCommand, TResult>> _logger;
+        private readonly ILogger<LoggingQueryBehavior<TQuery, TResult>> _logger;
 
-        public LoggingCommandBehavior(ILogger<LoggingCommandBehavior<TCommand, TResult>> logger)
+        public LoggingQueryBehavior(ILogger<LoggingQueryBehavior<TQuery, TResult>> logger)
         {
             _logger = logger;
         }
 
         public async Task<TResult> Handle(
-            TCommand command,
-            CommandHandlerDelegate<TResult> next,
+            TQuery command,
+            QueryHandlerDelegate<TResult> next,
             CancellationToken cancellationToken)
         {
-            var commandName = typeof(TCommand).Name;
-            _logger.LogInformation("Executing command {CommandName}", commandName);
+            var queryName = typeof(TQuery).Name;
+            _logger.LogInformation("Executing query {QueryName}", queryName);
 
             var stopwatch = Stopwatch.StartNew();   // start timing
             try
@@ -35,8 +35,8 @@ namespace Cortex.Mediator.Behaviors
 
                 stopwatch.Stop();
                 _logger.LogInformation(
-                    "Command {CommandName} executed successfully in {ElapsedMilliseconds} ms",
-                    commandName,
+                    "Query {QueryName} executed successfully in {ElapsedMilliseconds} ms",
+                    queryName,
                     stopwatch.ElapsedMilliseconds);
 
                 return result;
@@ -46,8 +46,8 @@ namespace Cortex.Mediator.Behaviors
                 stopwatch.Stop();
                 _logger.LogError(
                     ex,
-                    "Error executing command {CommandName} after {ElapsedMilliseconds} ms",
-                    commandName,
+                    "Error executing query {QueryName} after {ElapsedMilliseconds} ms",
+                    queryName,
                     stopwatch.ElapsedMilliseconds);
                 throw;
             }

--- a/src/Cortex.Mediator/Commands/ICommand.cs
+++ b/src/Cortex.Mediator/Commands/ICommand.cs
@@ -2,9 +2,10 @@
 {
     /// <summary>
     /// Represents a command in the CQRS pattern.
-    /// Commands are used to change the system state and do not return a value.
+    /// Commands are used to change the system state and do return a value. 
+    /// Please note that this is not a common practice in CQRS, as commands typically do not return values.
     /// </summary>
-    public interface ICommand
+    public interface ICommand<TResult>
     {
     }
 }

--- a/src/Cortex.Mediator/Commands/ICommandHandler.cs
+++ b/src/Cortex.Mediator/Commands/ICommandHandler.cs
@@ -7,14 +7,15 @@ namespace Cortex.Mediator.Commands
     /// Defines a handler for a command.
     /// </summary>
     /// <typeparam name="TCommand">The type of command being handled.</typeparam>
-    public interface ICommandHandler<in TCommand>
-        where TCommand : ICommand
+    /// <typeparam name="TResult">The type of command that is being returned.</typeparam>
+    public interface ICommandHandler<in TCommand, TResult>
+        where TCommand : ICommand<TResult>
     {
         /// <summary>
         /// Handles the specified command.
         /// </summary>
         /// <param name="command">The command to handle.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        Task Handle(TCommand command, CancellationToken cancellationToken);
+        Task<TResult> Handle(TCommand command, CancellationToken cancellationToken);
     }
 }

--- a/src/Cortex.Mediator/Commands/ICommandPipelineBehavior.cs
+++ b/src/Cortex.Mediator/Commands/ICommandPipelineBehavior.cs
@@ -7,20 +7,20 @@ namespace Cortex.Mediator.Commands
     /// Defines a pipeline behavior for wrapping command handlers.
     /// </summary>
     /// <typeparam name="TCommand">The type of command being handled.</typeparam>
-    public interface ICommandPipelineBehavior<in TCommand>
-        where TCommand : ICommand
+    public interface ICommandPipelineBehavior<in TCommand, TResult>
+        where TCommand : ICommand<TResult>
     {
         /// <summary>
         /// Handles the command and invokes the next behavior in the pipeline.
         /// </summary>
-        Task Handle(
+        Task<TResult> Handle(
             TCommand command,
-            CommandHandlerDelegate next,
+            CommandHandlerDelegate<TResult> next,
             CancellationToken cancellationToken);
     }
 
     /// <summary>
     /// Represents a delegate that wraps the command handler execution.
     /// </summary>
-    public delegate Task CommandHandlerDelegate();
+    public delegate Task<TResult> CommandHandlerDelegate<TResult>();
 }

--- a/src/Cortex.Mediator/Common/Unit.cs
+++ b/src/Cortex.Mediator/Common/Unit.cs
@@ -1,0 +1,8 @@
+﻿namespace Cortex.Mediator
+{
+    public readonly struct Unit
+    {
+        public static readonly Unit Value = new();
+        public override string ToString() => "()";
+    }
+}

--- a/src/Cortex.Mediator/DependencyInjection/MediatorOptionsExtensions.cs
+++ b/src/Cortex.Mediator/DependencyInjection/MediatorOptionsExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Cortex.Mediator.Behaviors;
-using Cortex.Mediator.Commands;
 
 namespace Cortex.Mediator.DependencyInjection
 {
@@ -8,7 +7,9 @@ namespace Cortex.Mediator.DependencyInjection
         public static MediatorOptions AddDefaultBehaviors(this MediatorOptions options)
         {
             return options
-                .AddCommandPipelineBehavior<LoggingCommandBehavior<ICommand>>();
+                // Register the open generic logging behavior for commands that return TResult
+                .AddOpenCommandPipelineBehavior(typeof(LoggingCommandBehavior<,>))
+                .AddOpenQueryPipelineBehavior(typeof(LoggingQueryBehavior<,>));
         }
     }
 }

--- a/src/Cortex.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Cortex.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
@@ -45,7 +45,7 @@ namespace Cortex.Mediator.DependencyInjection
             services.Scan(scan => scan
                 .FromAssemblies(assemblies)
                 .AddClasses(classes => classes
-                    .AssignableTo(typeof(ICommandHandler<>)), options.OnlyPublicClasses)
+                    .AssignableTo(typeof(ICommandHandler<,>)), options.OnlyPublicClasses)
                 .AsImplementedInterfaces()
                 .WithScopedLifetime());
 
@@ -69,7 +69,7 @@ namespace Cortex.Mediator.DependencyInjection
             // Command behaviors
             foreach (var behaviorType in options.CommandBehaviors)
             {
-                services.AddTransient(typeof(ICommandPipelineBehavior<>), behaviorType);
+                services.AddTransient(typeof(ICommandPipelineBehavior<,>), behaviorType);
             }
 
             // Query behaviors (if needed)

--- a/src/Cortex.Mediator/IMediator.cs
+++ b/src/Cortex.Mediator/IMediator.cs
@@ -11,12 +11,12 @@ namespace Cortex.Mediator
     /// </summary>
     public interface IMediator
     {
-        Task SendAsync<TCommand>(
+        Task<TResult> SendCommandAsync<TCommand, TResult>(
             TCommand command,
             CancellationToken cancellationToken = default)
-            where TCommand : ICommand;
+            where TCommand : ICommand<TResult>;
 
-        Task<TResult> SendAsync<TQuery, TResult>(
+        Task<TResult> SendQueryAsync<TQuery, TResult>(
             TQuery query,
             CancellationToken cancellationToken = default)
             where TQuery : IQuery<TResult>;

--- a/src/Cortex.Mediator/README.md
+++ b/src/Cortex.Mediator/README.md
@@ -9,9 +9,8 @@ Built as part of the [Cortex Data Framework](https://github.com/buildersoftio/co
 - ✅ Commands & Queries
 - ✅ Notifications (Events)
 - ✅ Pipeline Behaviors
-- ✅ FluentValidation
+- ✅ FluentValidation  - Coming in the next release v1.8
 - ✅ Logging
-- ✅ Transaction Handling
 
 ---
 
@@ -35,7 +34,7 @@ In `Program.cs` or `Startup.cs`:
 builder.Services.AddCortexMediator(
     builder.Configuration,
     new[] { typeof(Program) }, // Assemblies to scan for handlers
-    options => options.AddDefaultBehaviors() // Logging, Validation, Transaction
+    options => options.AddDefaultBehaviors() // Logging
 );
 ```
 
@@ -52,7 +51,7 @@ Features/
 ## ✏️ Defining a Command
 
 ```csharp
-public class CreateUserCommand : ICommand
+public class CreateUserCommand : ICommand<Guid>
 {
     public string UserName { get; set; }
     public string Email { get; set; }
@@ -61,16 +60,16 @@ public class CreateUserCommand : ICommand
 
 ### Handler
 ```csharp
-public class CreateUserCommandHandler : ICommandHandler<CreateUserCommand>
+public class CreateUserCommandHandler : ICommandHandler<CreateUserCommand,Guid>
 {
-    public async Task Handle(CreateUserCommand command, CancellationToken cancellationToken)
+    public async Task<Guid> Handle(CreateUserCommand command, CancellationToken cancellationToken)
     {
         // Logic here
     }
 }
 ```
 
-### Validator (Optional, via FluentValidation)
+### Validator (Optional, via FluentValidation) - Coming in the next release v1.8
 ```csharp
 public class CreateUserValidator : AbstractValidator<CreateUserCommand>
 {
@@ -126,9 +125,8 @@ await mediator.PublishAsync(new UserCreatedNotification { UserName = "Andy" });
 ## 🔧 Pipeline Behaviors (Built-in)
 Out of the box, Cortex.Mediator supports:
 
-- `ValidationCommandBehavior`
+- `ValidationCommandBehavior`  - Coming in the next release v1.8
 - `LoggingCommandBehavior`
-- `TransactionCommandBehavior`
 
 You can also register custom behaviors:
 ```csharp

--- a/src/Cortex.Tests/Cortex.Tests.csproj
+++ b/src/Cortex.Tests/Cortex.Tests.csproj
@@ -10,6 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Mediator\**" />
+    <EmbeddedResource Remove="Mediator\**" />
+    <None Remove="Mediator\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -30,10 +36,6 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Mediator\Tests\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Make ICommand and ICommandHandler generic (TResult)
- Update IMediator / Mediator to return TResult from commands
- Generalize pipeline & logging behaviors to TResult 
  - `CommandPipelineBehavior `
  - `LoggingCommandBehavior `
  - add `LoggingQueryBehavior`
- add `Common/Unit.cs` to represent “`void`” command results
- Update DI helpers (`MediatorOptions`*, `ServiceCollectionExtensions`)
- README updated

**BREAKING CHANGE**: All command handlers must now implement `ICommandHandler<TCommand, TResult>`. For commands that previously returned nothing, return Unit.