### PR TITLE
v2/feature/[Add support for Keys in Kafka Stream] #127:

### DIFF
--- a/src/Cortex.Streams.Kafka/Cortex.Streams.Kafka.csproj
+++ b/src/Cortex.Streams.Kafka/Cortex.Streams.Kafka.csproj
@@ -4,8 +4,8 @@
 		<TargetFrameworks>net8.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 
-		<AssemblyVersion>1.0.1</AssemblyVersion>
-		<FileVersion>1.0.1</FileVersion>
+		<AssemblyVersion>2.0.0</AssemblyVersion>
+		<FileVersion>2.0.0</FileVersion>
 		<Product>Buildersoft Cortex Framework</Product>
 		<Company>Buildersoft</Company>
 		<Authors>Buildersoft,EnesHoxha</Authors>
@@ -16,7 +16,7 @@
 		<RepositoryUrl>https://github.com/buildersoftio/cortex</RepositoryUrl>
 		<PackageTags>cortex vortex eda streaming distributed streams states kafka pulsar rocksdb</PackageTags>
 
-		<Version>1.0.1</Version>
+		<Version>2.0.0</Version>
 		<PackageLicenseFile>license.md</PackageLicenseFile>
 		<PackageIcon>cortex.png</PackageIcon>
 		<PackageId>Cortex.Streams.Kafka</PackageId>
@@ -52,9 +52,9 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Confluent.Kafka" Version="2.9.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.30.2" />
-		<PackageReference Include="protobuf-net" Version="3.2.46" />
+		<PackageReference Include="Confluent.Kafka" Version="2.11.0" />
+		<PackageReference Include="Google.Protobuf" Version="3.31.1" />
+		<PackageReference Include="protobuf-net" Version="3.2.55" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Cortex.Streams.Kafka/KafkaKeyValueSinkOperator.cs
+++ b/src/Cortex.Streams.Kafka/KafkaKeyValueSinkOperator.cs
@@ -1,0 +1,65 @@
+﻿using Confluent.Kafka;
+using Cortex.Streams.Kafka.Serializers;
+using Cortex.Streams.Operators;
+using System;
+using System.Collections.Generic;
+
+namespace Cortex.Streams.Kafka
+{
+    /// <summary>
+    /// Kafka sink that accepts KeyValuePair<TKey, TValue> so message keys are produced.
+    /// </summary>
+    public sealed class KafkaSinkOperator<TKey, TValue> : ISinkOperator<KeyValuePair<TKey, TValue>>
+    {
+        private readonly string _bootstrapServers;
+        private readonly string _topic;
+        private readonly IProducer<TKey, TValue> _producer;
+
+        public KafkaSinkOperator(
+                   string bootstrapServers,
+                   string topic,
+                   ProducerConfig config = null,
+                   ISerializer<TKey> keySerializer = null,
+                   ISerializer<TValue> valueSerializer = null)
+        {
+            _bootstrapServers = bootstrapServers ?? throw new ArgumentNullException(nameof(bootstrapServers));
+            _topic = topic ?? throw new ArgumentNullException(nameof(topic));
+
+            var producerConfig = config ?? new ProducerConfig
+            {
+                BootstrapServers = _bootstrapServers
+            };
+
+            keySerializer ??= new DefaultJsonSerializer<TKey>();
+            valueSerializer ??= new DefaultJsonSerializer<TValue>();
+
+            _producer = new ProducerBuilder<TKey, TValue>(producerConfig)
+                .SetKeySerializer(keySerializer)
+                .SetValueSerializer(valueSerializer)
+                .Build();
+        }
+
+        public void Process(KeyValuePair<TKey, TValue> input)
+        {
+            var msg = new Message<TKey, TValue> { Key = input.Key, Value = input.Value };
+            _producer.Produce(_topic, msg, deliveryReport =>
+            {
+                if (deliveryReport.Error.IsError)
+                {
+                    Console.WriteLine($"Delivery Error: {deliveryReport.Error.Reason}");
+                }
+            });
+        }
+
+        public void Start()
+        {
+            // no-op
+        }
+
+        public void Stop()
+        {
+            _producer.Flush(TimeSpan.FromSeconds(10));
+            _producer.Dispose();
+        }
+    }
+}

--- a/src/Cortex.Streams.Kafka/KafkaSinkOperator.cs
+++ b/src/Cortex.Streams.Kafka/KafkaSinkOperator.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Cortex.Streams.Kafka
 {
-    public class KafkaSinkOperator<TInput> : ISinkOperator<TInput>
+    public sealed class KafkaSinkOperator<TInput> : ISinkOperator<TInput>
     {
         private readonly string _bootstrapServers;
         private readonly string _topic;


### PR DESCRIPTION
Update Kafka integration and versioning for net8.0

- Updated `Cortex.Streams.Kafka.csproj` to target `net8.0` and increment version to `2.0.0`.
- Made `KafkaSinkOperator<TInput>` and `KafkaSourceOperator<TOutput>` classes sealed.
- Reformatted constructor parameters in `KafkaSourceOperator<TOutput>` for readability.
- Enhanced `Stop` method in `KafkaSourceOperator<TOutput>` with null checks and improved exception handling.
- Added `KafkaSinkOperator<TKey, TValue>` for producing messages with keys and values.
- Introduced `KafkaSourceOperator<TKey, TValue>` for consuming messages with keys and values.
- Both new classes include methods for processing and managing Kafka message flow.