### PR TITLE
v2/feature/128:

### DIFF
--- a/src/Cortex.Streams.Pulsar/Cortex.Streams.Pulsar.csproj
+++ b/src/Cortex.Streams.Pulsar/Cortex.Streams.Pulsar.csproj
@@ -62,10 +62,10 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="DotPulsar" Version="4.2.2" />
+		<PackageReference Include="DotPulsar" Version="4.3.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Google.Protobuf" Version="3.30.2" />
-		<PackageReference Include="protobuf-net" Version="3.2.46" />
+		<PackageReference Include="Google.Protobuf" Version="3.31.1" />
+		<PackageReference Include="protobuf-net" Version="3.2.55" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Update package versions for dependencies

- Updated `DotPulsar` from `4.2.2` to `4.3.1`
- Updated `Google.Protobuf` from `3.30.2` to `3.31.1`
- Updated `protobuf-net` from `3.2.46` to `3.2.55`