### PR TITLE
v2/feature/ #141 : Cortex.Mediator - Add Non Returning Command Interface (ICommand)

### DIFF
--- a/src/Cortex.Mediator/Behaviors/VoidLoggingCommandBehavior.cs
+++ b/src/Cortex.Mediator/Behaviors/VoidLoggingCommandBehavior.cs
@@ -1,0 +1,51 @@
+﻿using Cortex.Mediator.Commands;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cortex.Mediator.Behaviors
+{
+
+    public sealed class LoggingCommandBehavior<TCommand> : ICommandPipelineBehavior<TCommand> where TCommand : ICommand
+    {
+        private readonly ILogger<LoggingCommandBehavior<TCommand>> _logger;
+
+        public LoggingCommandBehavior(ILogger<LoggingCommandBehavior<TCommand>> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task Handle(
+            TCommand command,
+            CommandHandlerDelegate next,
+            CancellationToken cancellationToken)
+        {
+            var commandName = typeof(TCommand).Name;
+            _logger.LogInformation("Executing command {CommandName}", commandName);
+
+            var stopwatch = Stopwatch.StartNew();   // start timing
+            try
+            {
+                await next();
+
+                stopwatch.Stop();
+                _logger.LogInformation(
+                    "Command {CommandName} executed successfully in {ElapsedMilliseconds} ms",
+                    commandName,
+                    stopwatch.ElapsedMilliseconds);
+            }
+            catch (Exception ex)
+            {
+                stopwatch.Stop();
+                _logger.LogError(
+                    ex,
+                    "Error executing command {CommandName} after {ElapsedMilliseconds} ms",
+                    commandName,
+                    stopwatch.ElapsedMilliseconds);
+                throw;
+            }
+        }
+    }
+}

--- a/src/Cortex.Mediator/Commands/ICommand.cs
+++ b/src/Cortex.Mediator/Commands/ICommand.cs
@@ -8,4 +8,14 @@
     public interface ICommand<TResult>
     {
     }
+
+    // feature #141
+
+    /// <summary>
+    /// Represents a command in the CQRS pattern.
+    /// Commands are used to change the system state and do not return a value. 
+    /// </summary>
+    public interface ICommand
+    {
+    }
 }

--- a/src/Cortex.Mediator/Commands/ICommandHandler.cs
+++ b/src/Cortex.Mediator/Commands/ICommandHandler.cs
@@ -18,4 +18,23 @@ namespace Cortex.Mediator.Commands
         /// <param name="cancellationToken">The cancellation token.</param>
         Task<TResult> Handle(TCommand command, CancellationToken cancellationToken);
     }
+
+
+
+    // feature #141
+
+    /// <summary>
+    /// Defines a handler for a command.
+    /// </summary>
+    /// <typeparam name="TCommand">The type of command being handled.</typeparam>
+    public interface ICommandHandler<in TCommand>
+        where TCommand : ICommand
+    {
+        /// <summary>
+        /// Handles the specified command.
+        /// </summary>
+        /// <param name="command">The command to handle.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        Task Handle(TCommand command, CancellationToken cancellationToken);
+    }
 }

--- a/src/Cortex.Mediator/Commands/ICommandPipelineBehavior.cs
+++ b/src/Cortex.Mediator/Commands/ICommandPipelineBehavior.cs
@@ -19,8 +19,33 @@ namespace Cortex.Mediator.Commands
             CancellationToken cancellationToken);
     }
 
+
+    // For non returning commands
+    // feature #141
+
+    /// <summary>
+    /// Defines a pipeline behavior for wrapping command handlers.
+    /// </summary>
+    /// <typeparam name="TCommand">The type of command being handled.</typeparam>
+    public interface ICommandPipelineBehavior<in TCommand>
+        where TCommand : ICommand
+    {
+        /// <summary>
+        /// Handles the command and invokes the next behavior in the pipeline.
+        /// </summary>
+        Task Handle(
+            TCommand command,
+            CommandHandlerDelegate next,
+            CancellationToken cancellationToken);
+    }
+
     /// <summary>
     /// Represents a delegate that wraps the command handler execution.
     /// </summary>
     public delegate Task<TResult> CommandHandlerDelegate<TResult>();
+
+    /// <summary>
+    /// Represents a delegate that wraps the command handler execution.
+    /// </summary>
+    public delegate Task CommandHandlerDelegate();
 }

--- a/src/Cortex.Mediator/DependencyInjection/MediatorOptionsExtensions.cs
+++ b/src/Cortex.Mediator/DependencyInjection/MediatorOptionsExtensions.cs
@@ -9,7 +9,8 @@ namespace Cortex.Mediator.DependencyInjection
             return options
                 // Register the open generic logging behavior for commands that return TResult
                 .AddOpenCommandPipelineBehavior(typeof(LoggingCommandBehavior<,>))
-                .AddOpenQueryPipelineBehavior(typeof(LoggingQueryBehavior<,>));
+                .AddOpenQueryPipelineBehavior(typeof(LoggingQueryBehavior<,>))
+                .AddOpenCommandPipelineBehavior(typeof(LoggingCommandBehavior<>)); // Add void command logging
         }
     }
 }

--- a/src/Cortex.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Cortex.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
@@ -49,6 +49,14 @@ namespace Cortex.Mediator.DependencyInjection
                 .AsImplementedInterfaces()
                 .WithScopedLifetime());
 
+            // feature #141 - Register void command handlers
+            services.Scan(scan => scan
+                .FromAssemblies(assemblies)
+                .AddClasses(classes => classes
+                    .AssignableTo(typeof(ICommandHandler<>)), options.OnlyPublicClasses)
+                .AsImplementedInterfaces()
+                .WithScopedLifetime());
+
             services.Scan(scan => scan
                 .FromAssemblies(assemblies)
                 .AddClasses(classes => classes
@@ -70,6 +78,12 @@ namespace Cortex.Mediator.DependencyInjection
             foreach (var behaviorType in options.CommandBehaviors)
             {
                 services.AddTransient(typeof(ICommandPipelineBehavior<,>), behaviorType);
+            }
+
+            // feature #141 - Register non-returning command pipeline behaviors
+            foreach (var behaviorType in options.VoidCommandBehaviors)
+            {
+                services.AddTransient(typeof(ICommandPipelineBehavior<>), behaviorType);
             }
 
             // Query behaviors (if needed)

--- a/src/Cortex.Mediator/IMediator.cs
+++ b/src/Cortex.Mediator/IMediator.cs
@@ -16,6 +16,11 @@ namespace Cortex.Mediator
             CancellationToken cancellationToken = default)
             where TCommand : ICommand<TResult>;
 
+        Task SendCommandAsync<TCommand>(
+            TCommand command,
+            CancellationToken cancellationToken = default)
+            where TCommand : ICommand;
+
         Task<TResult> SendQueryAsync<TQuery, TResult>(
             TQuery query,
             CancellationToken cancellationToken = default)


### PR DESCRIPTION
v2/feature/ #141: Cortex.Mediator - Add Non-Returning Command Interface (ICommand)

Add support for **non-returning CQRS commands**

Introduced a non-generic `ICommand` interface for commands that do not return values, alongside a corresponding `ICommandHandler<TCommand>` interface. Added `ICommandPipelineBehavior<TCommand>` and `CommandHandlerDelegate` to enable pipeline behaviors for non-returning commands.

Updated `MediatorOptions` to manage both returning and non-returning command behaviors, including the addition of `VoidCommandBehaviors`. Enhanced `MediatorOptionsExtensions` and `ServiceCollectionExtensions` to register default and custom behaviors for non-returning commands.

Extended `IMediator` with a `SendCommandAsync<TCommand>` method for non-returning commands. Updated the `Mediator` implementation to handle non-returning commands and added a `PipelineBehaviorNextDelegate<TCommand>` for behavior chaining.

Added `VoidLoggingCommandBehavior` to log execution details for non-returning commands. Refactored existing code to ensure compatibility with the new non-returning command infrastructure.