### PR TITLE
Feature/164 allow fluentvalidation to be used

### DIFF
--- a/Cortex.sln
+++ b/Cortex.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.0.11111.16 d18.0
+VisualStudioVersion = 18.0.11111.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cortex.Mediator", "src\Cortex.Mediator\Cortex.Mediator.csproj", "{F1CC775A-95DA-4A5A-879F-66BFCB0FDCC9}"
 EndProject
@@ -129,6 +129,7 @@ Global
 		{D51C6B82-ABD9-4C43-820E-237EDBD706A1}.Release|Any CPU.ActiveCfg = Release|AnyCPU
 		{D51C6B82-ABD9-4C43-820E-237EDBD706A1}.Release|Any CPU.Build.0 = Release|AnyCPU
 		{C9A7699A-9BCF-4B51-B29F-ABF78DCEA553}.Debug|Any CPU.ActiveCfg = Debug|AnyCPU
+		{C9A7699A-9BCF-4B51-B29F-ABF78DCEA553}.Debug|Any CPU.Build.0 = Debug|AnyCPU
 		{C9A7699A-9BCF-4B51-B29F-ABF78DCEA553}.Release|Any CPU.ActiveCfg = Release|AnyCPU
 		{C9A7699A-9BCF-4B51-B29F-ABF78DCEA553}.Release|Any CPU.Build.0 = Release|AnyCPU
 		{D376D6CA-3192-4EDC-B840-31F58B6457DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/src/Cortex.Mediator.Behaviors.FluentValidation/DependencyInjection/MediatorOptionsExtensions.cs
+++ b/src/Cortex.Mediator.Behaviors.FluentValidation/DependencyInjection/MediatorOptionsExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Cortex.Mediator.DependencyInjection;
+
+namespace Cortex.Mediator.Behaviors.FluentValidation.DependencyInjection
+{
+    public static class MediatorOptionsExtensions
+    {
+        public static MediatorOptions AddFluentValidationBehaviors(this MediatorOptions options)
+        {
+            options.AddOpenCommandPipelineBehavior(typeof(ValidationCommandBehavior<,>))
+                .AddOpenQueryPipelineBehavior(typeof(ValidationQueryBehavior<,>))
+                .AddOpenCommandPipelineBehavior(typeof(ValidationCommandBehavior<>));
+
+            return options;
+        }
+    }
+}

--- a/src/Cortex.Mediator.Behaviors.FluentValidation/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Cortex.Mediator.Behaviors.FluentValidation/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+
+namespace Cortex.Mediator.Behaviors.FluentValidation.DependencyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddFluentValidationValidators(this IServiceCollection services, Type[] validationAssemblyMarkerTypes)
+        {
+            services.AddValidatorsFromAssemblies(validationAssemblyMarkerTypes.Select(t => t.Assembly));
+            return services;
+        }
+    }
+}

--- a/src/Cortex.Mediator.Behaviors.FluentValidation/ValidationCommandBehavior.cs
+++ b/src/Cortex.Mediator.Behaviors.FluentValidation/ValidationCommandBehavior.cs
@@ -1,6 +1,5 @@
 ﻿using Cortex.Mediator.Commands;
 using FluentValidation;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -16,12 +15,17 @@ namespace Cortex.Mediator.Behaviors
     {
         private readonly IEnumerable<IValidator<TCommand>> _validators;
 
+        public ValidationCommandBehavior(IEnumerable<IValidator<TCommand>> validators)
+        {
+            _validators = validators;
+        }
 
         public async Task<TResult> Handle(TCommand command, CommandHandlerDelegate<TResult> next, CancellationToken cancellationToken)
         {
             var context = new ValidationContext<TCommand>(command);
             var failures = _validators
-                .Select(v => v.Validate(context))
+                .Select(async v => await v.ValidateAsync(context))
+                .Select(r => r.Result)
                 .SelectMany(r => r.Errors)
                 .Where(f => f != null)
                 .ToList();

--- a/src/Cortex.Mediator.Behaviors.FluentValidation/ValidationQueryBehavior.cs
+++ b/src/Cortex.Mediator.Behaviors.FluentValidation/ValidationQueryBehavior.cs
@@ -13,12 +13,18 @@ namespace Cortex.Mediator.Behaviors.FluentValidation
 
         private readonly IEnumerable<IValidator<TQuery>> _validators;
 
+        public ValidationQueryBehavior(IEnumerable<IValidator<TQuery>> validators)
+        {
+            _validators = validators;
+        }
+
 
         public async Task<TResult> Handle(TQuery query, QueryHandlerDelegate<TResult> next, CancellationToken cancellationToken)
         {
             var context = new ValidationContext<TQuery>(query);
             var failures = _validators
-                .Select(v => v.Validate(context))
+                .Select(async v => await v.ValidateAsync(context))
+                .Select(r => r.Result)
                 .SelectMany(r => r.Errors)
                 .Where(f => f != null)
                 .ToList();

--- a/src/Cortex.Mediator.Behaviors.FluentValidation/VoidValidationCommandBehavior.cs
+++ b/src/Cortex.Mediator.Behaviors.FluentValidation/VoidValidationCommandBehavior.cs
@@ -15,12 +15,18 @@ namespace Cortex.Mediator.Behaviors
     {
         private readonly IEnumerable<IValidator<TCommand>> _validators;
 
+        public ValidationCommandBehavior(IEnumerable<IValidator<TCommand>> validators)
+        {
+            _validators = validators;
+        }
+
 
         public async Task Handle(TCommand command, CommandHandlerDelegate next, CancellationToken cancellationToken)
         {
             var context = new ValidationContext<TCommand>(command);
             var failures = _validators
-                .Select(v => v.Validate(context))
+                .Select(async v => await v.ValidateAsync(context))
+                .Select(r => r.Result)
                 .SelectMany(r => r.Errors)
                 .Where(f => f != null)
                 .ToList();

--- a/src/Cortex.Tests/Cortex.Tests.csproj
+++ b/src/Cortex.Tests/Cortex.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,12 +8,6 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="Mediator\**" />
-    <EmbeddedResource Remove="Mediator\**" />
-    <None Remove="Mediator\**" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4">
@@ -30,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Cortex.Mediator.Behaviors.FluentValidation\Cortex.Mediator.Behaviors.FluentValidation.csproj" />
     <ProjectReference Include="..\Cortex.Mediator\Cortex.Mediator.csproj" />
     <ProjectReference Include="..\Cortex.Streams\Cortex.Streams.csproj" />
   </ItemGroup>

--- a/src/Cortex.Tests/Mediator/FluentValidation/Tests/ValidationCommandBehaviorTests.cs
+++ b/src/Cortex.Tests/Mediator/FluentValidation/Tests/ValidationCommandBehaviorTests.cs
@@ -1,0 +1,70 @@
+﻿using Cortex.Mediator.Behaviors;
+using Cortex.Mediator.Commands;
+using FluentValidation;
+using FluentValidation.Results;
+using Moq;
+
+namespace Cortex.Tests.Mediator.FluentValidation.Tests
+{
+    public class ValidationCommandBehaviorTests
+    {
+        public class FakeCommand : ICommand<string>
+        {
+        }
+
+        [Fact]
+        public async Task Handle_ShouldNotThrowExceptionsWhenThereAreNoValidationFailures()
+        {
+            // Arrange
+            var expectedResult = "completed";
+            var validator = new Mock<IValidator<FakeCommand>>();
+            validator.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), default)).Returns(() => Task.FromResult(new ValidationResult { Errors = new List<ValidationFailure>()}));
+            var validators = new IValidator<FakeCommand>[]
+            {
+                    validator.Object,
+            };
+
+            var next = new Mock<CommandHandlerDelegate<string>>();
+            next.Setup(n => n.Invoke()).Returns(Task.FromResult(expectedResult));
+            var systemUnderTest = new ValidationCommandBehavior<FakeCommand, string>(validators);
+
+            // Act
+
+            var result = await systemUnderTest.Handle(new FakeCommand(), next.Object, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldThrowAnExceptionsWhenThereIsAValidationFailure()
+        {
+            // Arrange
+            var expectedResult = "completed";
+            var validator = new Mock<IValidator<FakeCommand>>();
+            validator.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), default))
+                .Returns(() => Task.FromResult(new ValidationResult 
+                { 
+                    Errors = new List<ValidationFailure> 
+                    { 
+                        new ValidationFailure("some-property", "was invalid")
+                    } 
+                }
+            ));
+
+            var validators = new IValidator<FakeCommand>[]
+            {
+                    validator.Object,
+            };
+
+            var next = new Mock<CommandHandlerDelegate<string>>();
+            next.Setup(n => n.Invoke()).Returns(Task.FromResult(expectedResult));
+            var systemUnderTest = new ValidationCommandBehavior<FakeCommand, string>(validators);
+
+            // Act
+            // Assert
+            await Assert.ThrowsAsync<Cortex.Mediator.Exceptions.ValidationException>(async () => await systemUnderTest.Handle(new FakeCommand(), next.Object, CancellationToken.None));
+        }
+    }
+}

--- a/src/Cortex.Tests/Mediator/FluentValidation/Tests/ValidationQueryBehaviorTests.cs
+++ b/src/Cortex.Tests/Mediator/FluentValidation/Tests/ValidationQueryBehaviorTests.cs
@@ -1,0 +1,69 @@
+﻿using Cortex.Mediator.Behaviors.FluentValidation;
+using Cortex.Mediator.Queries;
+using FluentValidation;
+using FluentValidation.Results;
+using Moq;
+
+namespace Cortex.Tests.Mediator.FluentValidation.Tests
+{
+    public class FakeQuery : IQuery<string>
+    {
+    }
+
+    public class ValidationQueryBehaviorTests
+    {
+        [Fact]
+        public async Task Handle_ShouldNotThrowExceptionsWhenThereAreNoValidationFailures()
+        {
+            // Arrange
+            var expectedResult = "completed";
+            var validator = new Mock<IValidator<FakeQuery>>();
+            validator.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), default)).Returns(() => Task.FromResult(new ValidationResult { Errors = new List<ValidationFailure>()}));
+            var validators = new IValidator<FakeQuery>[]
+            {
+                    validator.Object,
+            };
+
+            var next = new Mock<QueryHandlerDelegate<string>>();
+            next.Setup(n => n.Invoke()).Returns(Task.FromResult(expectedResult));
+            var systemUnderTest = new ValidationQueryBehavior<FakeQuery, string>(validators);
+
+            // Act
+            var result = await systemUnderTest.Handle(new FakeQuery(), next.Object, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldThrowAnExceptionsWhenThereIsAValidationFailure()
+        {
+            // Arrange
+            var expectedResult = "completed";
+            var validator = new Mock<IValidator<FakeQuery>>();
+            validator.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), default))
+                .Returns(() => Task.FromResult(new ValidationResult 
+                {
+                    Errors =
+                    [
+                        new("some-property", "was invalid")
+                    ] 
+                }
+            ));
+
+            var validators = new IValidator<FakeQuery>[]
+            {
+                    validator.Object,
+            };
+
+            var next = new Mock<QueryHandlerDelegate<string>>();
+            next.Setup(n => n.Invoke()).Returns(Task.FromResult(expectedResult));
+            var systemUnderTest = new ValidationQueryBehavior<FakeQuery, string>(validators);
+
+            // Act
+            // Assert
+            await Assert.ThrowsAsync<Cortex.Mediator.Exceptions.ValidationException>(async () => await systemUnderTest.Handle(new FakeQuery(), next.Object, CancellationToken.None));
+        }
+    }
+}

--- a/src/Cortex.Tests/Mediator/FluentValidation/Tests/VoidValidationCommandBehaviorTests.cs
+++ b/src/Cortex.Tests/Mediator/FluentValidation/Tests/VoidValidationCommandBehaviorTests.cs
@@ -1,0 +1,66 @@
+﻿using Cortex.Mediator.Behaviors;
+using Cortex.Mediator.Commands;
+using FluentValidation;
+using FluentValidation.Results;
+using Moq;
+
+namespace Cortex.Tests.Mediator.FluentValidation.Tests
+{
+    public class FakeVoidCommand : ICommand
+    {
+    }
+
+    public class VoidValidationCommandBehaviorTests
+    {
+        [Fact]
+        public async Task Handle_ShouldNotThrowExceptionsWhenThereAreNoValidationFailures()
+        {
+            // Arrange
+            var expectedResult = "completed";
+            var validator = new Mock<IValidator<FakeVoidCommand>>();
+            validator.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), default)).Returns(() => Task.FromResult(new ValidationResult { Errors = new List<ValidationFailure>()}));
+            var validators = new IValidator<FakeVoidCommand>[]
+            {
+                    validator.Object,
+            };
+
+            var next = new Mock<CommandHandlerDelegate>();
+            next.Setup(n => n.Invoke()).Returns(Task.FromResult(expectedResult));
+            var systemUnderTest = new ValidationCommandBehavior<FakeVoidCommand>(validators);
+
+            // Act 
+            // Assert
+            await systemUnderTest.Handle(new FakeVoidCommand(), next.Object, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldThrowAnExceptionsWhenThereIsAValidationFailure()
+        {
+            // Arrange
+            var expectedResult = "completed";
+            var validator = new Mock<IValidator<FakeVoidCommand>>();
+            validator.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), default))
+                .Returns(() => Task.FromResult(new ValidationResult 
+                { 
+                    Errors = new List<ValidationFailure> 
+                    { 
+                        new ValidationFailure("some-property", "was invalid")
+                    } 
+                }
+            ));
+
+            var validators = new IValidator<FakeVoidCommand>[]
+            {
+                    validator.Object,
+            };
+
+            var next = new Mock<CommandHandlerDelegate>();
+            next.Setup(n => n.Invoke()).Returns(Task.FromResult(expectedResult));
+            var systemUnderTest = new ValidationCommandBehavior<FakeVoidCommand>(validators);
+
+            // Act
+            // Assert
+            await Assert.ThrowsAsync<Cortex.Mediator.Exceptions.ValidationException>(async () => await systemUnderTest.Handle(new FakeVoidCommand(), next.Object, CancellationToken.None));
+        }
+    }
+}


### PR DESCRIPTION
Add extension methods to allow consumers to opt-in to using FluentValidation validators