### PR TITLE
v2.2/bug/161: Refactor AddCortexMediator method signature

### DIFF
--- a/src/Cortex.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Cortex.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
@@ -15,9 +15,8 @@ namespace Cortex.Mediator.DependencyInjection
     {
         public static IServiceCollection AddCortexMediator(
             this IServiceCollection services,
-            IConfiguration configuration,
             Type[] handlerAssemblyMarkerTypes,
-            Action<MediatorOptions>? configure = null)
+            Action<MediatorOptions> configure = null)
         {
             var options = new MediatorOptions();
             configure?.Invoke(options);


### PR DESCRIPTION
Removed the IConfiguration parameter from AddCortexMediator and made the configure parameter non-nullable. This streamlines service registration and eliminates the need to provide a configuration object.