### PR TITLE
v3/feature/162: Simplify Mediator API with type-inferred commands/queries

### DIFF
--- a/src/Cortex.Mediator/IMediator.cs
+++ b/src/Cortex.Mediator/IMediator.cs
@@ -11,21 +11,80 @@ namespace Cortex.Mediator
     /// </summary>
     public interface IMediator
     {
+        /// <summary>
+        /// Sends a command with explicit type parameters.
+        /// </summary>
+        /// <typeparam name="TCommand">The type of command being sent.</typeparam>
+        /// <typeparam name="TResult">The type of result returned by the command.</typeparam>
+        /// <param name="command">The command to send.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The result of the command execution.</returns>
         Task<TResult> SendCommandAsync<TCommand, TResult>(
             TCommand command,
             CancellationToken cancellationToken = default)
             where TCommand : ICommand<TResult>;
 
+        /// <summary>
+        /// Sends a command that returns a result. The result type is inferred from the command interface.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result returned by the command (inferred from ICommand&lt;TResult&gt;).</typeparam>
+        /// <param name="command">The command to send.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The result of the command execution.</returns>
+        Task<TResult> SendCommandAsync<TResult>(
+            ICommand<TResult> command,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a command with explicit type parameter that does not return a value.
+        /// </summary>
+        /// <typeparam name="TCommand">The type of command being sent.</typeparam>
+        /// <param name="command">The command to send.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         Task SendCommandAsync<TCommand>(
             TCommand command,
             CancellationToken cancellationToken = default)
             where TCommand : ICommand;
 
+        /// <summary>
+        /// Sends a command that does not return a value.
+        /// </summary>
+        /// <param name="command">The command to send.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        Task SendCommandAsync(
+            ICommand command,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a query with explicit type parameters.
+        /// </summary>
+        /// <typeparam name="TQuery">The type of query being sent.</typeparam>
+        /// <typeparam name="TResult">The type of result returned by the query.</typeparam>
+        /// <param name="query">The query to send.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The result of the query execution.</returns>
         Task<TResult> SendQueryAsync<TQuery, TResult>(
             TQuery query,
             CancellationToken cancellationToken = default)
             where TQuery : IQuery<TResult>;
 
+        /// <summary>
+        /// Sends a query that returns a result. The result type is inferred from the query interface.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result returned by the query (inferred from IQuery&lt;TResult&gt;).</typeparam>
+        /// <param name="query">The query to send.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The result of the query execution.</returns>
+        Task<TResult> SendQueryAsync<TResult>(
+            IQuery<TResult> query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Publishes a notification to all registered handlers.
+        /// </summary>
+        /// <typeparam name="TNotification">The type of notification being published.</typeparam>
+        /// <param name="notification">The notification to publish.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         Task PublishAsync<TNotification>(
             TNotification notification,
             CancellationToken cancellationToken = default)

--- a/src/Cortex.Mediator/Mediator.cs
+++ b/src/Cortex.Mediator/Mediator.cs
@@ -3,7 +3,9 @@ using Cortex.Mediator.Notifications;
 using Cortex.Mediator.Queries;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,6 +17,11 @@ namespace Cortex.Mediator
     public class Mediator : IMediator
     {
         private readonly IServiceProvider _serviceProvider;
+
+        // Cache for reflection-based method lookups to improve performance
+        private static readonly ConcurrentDictionary<Type, MethodInfo> _sendCommandMethodCache = new();
+        private static readonly ConcurrentDictionary<Type, MethodInfo> _sendQueryMethodCache = new();
+        private static readonly ConcurrentDictionary<Type, MethodInfo> _sendVoidCommandMethodCache = new();
 
         public Mediator(IServiceProvider serviceProvider)
         {
@@ -34,6 +41,28 @@ namespace Cortex.Mediator
             return await handler.Handle(command, cancellationToken);
         }
 
+        public Task<TResult> SendCommandAsync<TResult>(ICommand<TResult> command, CancellationToken cancellationToken = default)
+        {
+            if (command == null)
+                throw new ArgumentNullException(nameof(command));
+
+            var commandType = command.GetType();
+            var resultType = typeof(TResult);
+
+            var method = _sendCommandMethodCache.GetOrAdd(commandType, type =>
+            {
+                var genericMethod = typeof(Mediator)
+                    .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                    .First(m => m.Name == nameof(SendCommandAsync) &&
+                                m.IsGenericMethodDefinition &&
+                                m.GetGenericArguments().Length == 2);
+
+                return genericMethod.MakeGenericMethod(type, resultType);
+            });
+
+            return (Task<TResult>)method.Invoke(this, new object[] { command, cancellationToken })!;
+        }
+
         public async Task SendCommandAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default) where TCommand : ICommand
         {
             var handler = _serviceProvider.GetRequiredService<ICommandHandler<TCommand>>();
@@ -44,6 +73,29 @@ namespace Cortex.Mediator
             }
 
             await handler.Handle(command, cancellationToken);
+        }
+
+        public Task SendCommandAsync(ICommand command, CancellationToken cancellationToken = default)
+        {
+            if (command == null)
+                throw new ArgumentNullException(nameof(command));
+
+            var commandType = command.GetType();
+
+            var method = _sendVoidCommandMethodCache.GetOrAdd(commandType, type =>
+            {
+                var genericMethod = typeof(Mediator)
+                    .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                    .First(m => m.Name == nameof(SendCommandAsync) &&
+                                m.IsGenericMethodDefinition &&
+                                m.GetGenericArguments().Length == 1 &&
+                                m.GetParameters().Length == 2 &&
+                                m.GetParameters()[0].ParameterType.IsGenericParameter);
+
+                return genericMethod.MakeGenericMethod(type);
+            });
+
+            return (Task)method.Invoke(this, new object[] { command, cancellationToken })!;
         }
 
         public async Task<TResult> SendQueryAsync<TQuery, TResult>(TQuery query, CancellationToken cancellationToken = default)
@@ -57,6 +109,28 @@ namespace Cortex.Mediator
             }
 
             return await handler.Handle(query, cancellationToken);
+        }
+
+        public Task<TResult> SendQueryAsync<TResult>(IQuery<TResult> query, CancellationToken cancellationToken = default)
+        {
+            if (query == null)
+                throw new ArgumentNullException(nameof(query));
+
+            var queryType = query.GetType();
+            var resultType = typeof(TResult);
+
+            var method = _sendQueryMethodCache.GetOrAdd(queryType, type =>
+            {
+                var genericMethod = typeof(Mediator)
+                    .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                    .First(m => m.Name == nameof(SendQueryAsync) &&
+                                m.IsGenericMethodDefinition &&
+                                m.GetGenericArguments().Length == 2);
+
+                return genericMethod.MakeGenericMethod(type, resultType);
+            });
+
+            return (Task<TResult>)method.Invoke(this, new object[] { query, cancellationToken })!;
         }
 
         public async Task PublishAsync<TNotification>(

--- a/src/Cortex.Mediator/MediatorExtensions.cs
+++ b/src/Cortex.Mediator/MediatorExtensions.cs
@@ -1,0 +1,83 @@
+using Cortex.Mediator.Commands;
+using Cortex.Mediator.Queries;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cortex.Mediator
+{
+    /// <summary>
+    /// Extension methods for <see cref="IMediator"/> that provide simplified API 
+    /// with automatic type inference for commands and queries.
+    /// </summary>
+    public static class MediatorExtensions
+    {
+        /// <summary>
+        /// Sends a command and returns the result. The result type is inferred from the command.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result returned by the command (inferred).</typeparam>
+        /// <param name="mediator">The mediator instance.</param>
+        /// <param name="command">The command to send.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The result of the command execution.</returns>
+        /// <example>
+        /// <code>
+        /// // Instead of:
+        /// var result = await mediator.SendCommandAsync&lt;CreateUserCommand, Guid&gt;(command);
+        /// 
+        /// // You can now write:
+        /// var result = await mediator.SendAsync(command);
+        /// </code>
+        /// </example>
+        public static Task<TResult> SendAsync<TResult>(
+            this IMediator mediator,
+            ICommand<TResult> command,
+            CancellationToken cancellationToken = default)
+        {
+            return mediator.SendCommandAsync(command, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends a command that does not return a value.
+        /// </summary>
+        /// <param name="mediator">The mediator instance.</param>
+        /// <param name="command">The command to send.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <example>
+        /// <code>
+        /// await mediator.SendAsync(new DeleteUserCommand { UserId = userId });
+        /// </code>
+        /// </example>
+        public static Task SendAsync(
+            this IMediator mediator,
+            ICommand command,
+            CancellationToken cancellationToken = default)
+        {
+            return mediator.SendCommandAsync(command, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends a query and returns the result. The result type is inferred from the query.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result returned by the query (inferred).</typeparam>
+        /// <param name="mediator">The mediator instance.</param>
+        /// <param name="query">The query to send.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The result of the query execution.</returns>
+        /// <example>
+        /// <code>
+        /// // Instead of:
+        /// var user = await mediator.SendQueryAsync&lt;GetUserQuery, UserDto&gt;(query);
+        /// 
+        /// // You can now write:
+        /// var user = await mediator.QueryAsync(query);
+        /// </code>
+        /// </example>
+        public static Task<TResult> QueryAsync<TResult>(
+            this IMediator mediator,
+            IQuery<TResult> query,
+            CancellationToken cancellationToken = default)
+        {
+            return mediator.SendQueryAsync(query, cancellationToken);
+        }
+    }
+}

--- a/src/Cortex.Mediator/README.md
+++ b/src/Cortex.Mediator/README.md
@@ -69,6 +69,22 @@ public class CreateUserCommandHandler : ICommandHandler<CreateUserCommand,Guid>
 }
 ```
 
+### Sending Commands
+
+**Simplified API (Recommended)** - Type is automatically inferred:
+```csharp
+// Using extension methods - no need to specify type parameters!
+var userId = await mediator.SendAsync(command);
+
+// For void commands (no return value)
+await mediator.SendAsync(new DeleteUserCommand { UserId = userId });
+```
+
+**Explicit Type Parameters** (Legacy):
+```csharp
+var userId = await mediator.SendCommandAsync<CreateUserCommand, Guid>(command);
+```
+
 ### Validator (Optional, via FluentValidation)
 ```csharp
 public class CreateUserValidator : AbstractValidator<CreateUserCommand>
@@ -100,6 +116,19 @@ public class GetUserQueryHandler : IQueryHandler<GetUserQuery, GetUserResponse>
     }
 }
 
+```
+
+### Sending Queries
+
+**Simplified API (Recommended)** - Type is automatically inferred:
+```csharp
+// Using extension methods - no need to specify type parameters!
+var user = await mediator.QueryAsync(new GetUserQuery { UserId = 1 });
+```
+
+**Explicit Type Parameters** (Legacy):
+```csharp
+var user = await mediator.SendQueryAsync<GetUserQuery, GetUserResponse>(query);
 ```
 
 ## 📢 Notifications (Events)

--- a/src/Cortex.Tests/Mediator/Tests/MediatorPipelineTests.cs
+++ b/src/Cortex.Tests/Mediator/Tests/MediatorPipelineTests.cs
@@ -1,0 +1,260 @@
+using Cortex.Mediator;
+using Cortex.Mediator.Commands;
+using Cortex.Mediator.Queries;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cortex.Tests.Mediator.Tests
+{
+    #region Test Commands, Queries, and Behaviors for Pipeline Tests
+
+    public class LoggedCommand : ICommand<string>
+    {
+        public string Input { get; set; } = string.Empty;
+    }
+
+    public class LoggedCommandHandler : ICommandHandler<LoggedCommand, string>
+    {
+        public Task<string> Handle(LoggedCommand command, CancellationToken cancellationToken)
+        {
+            return Task.FromResult($"Processed: {command.Input}");
+        }
+    }
+
+    public class LoggedVoidCommand : ICommand
+    {
+        public string Input { get; set; } = string.Empty;
+    }
+
+    public class LoggedVoidCommandHandler : ICommandHandler<LoggedVoidCommand>
+    {
+        public List<string> ExecutionLog { get; } = new();
+
+        public Task Handle(LoggedVoidCommand command, CancellationToken cancellationToken)
+        {
+            ExecutionLog.Add($"Handler: {command.Input}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public class LoggedQuery : IQuery<string>
+    {
+        public string Input { get; set; } = string.Empty;
+    }
+
+    public class LoggedQueryHandler : IQueryHandler<LoggedQuery, string>
+    {
+        public Task<string> Handle(LoggedQuery query, CancellationToken cancellationToken)
+        {
+            return Task.FromResult($"Query Result: {query.Input}");
+        }
+    }
+
+    /// <summary>
+    /// Test pipeline behavior that logs before and after execution
+    /// </summary>
+    public class TestCommandPipelineBehavior<TCommand, TResult> : ICommandPipelineBehavior<TCommand, TResult>
+        where TCommand : ICommand<TResult>
+    {
+        private readonly List<string> _log;
+
+        public TestCommandPipelineBehavior(List<string> log)
+        {
+            _log = log;
+        }
+
+        public async Task<TResult> Handle(TCommand command, CommandHandlerDelegate<TResult> next, CancellationToken cancellationToken)
+        {
+            _log.Add("Before Command");
+            var result = await next();
+            _log.Add("After Command");
+            return result;
+        }
+    }
+
+    public class TestVoidCommandPipelineBehavior<TCommand> : ICommandPipelineBehavior<TCommand>
+        where TCommand : ICommand
+    {
+        private readonly List<string> _log;
+
+        public TestVoidCommandPipelineBehavior(List<string> log)
+        {
+            _log = log;
+        }
+
+        public async Task Handle(TCommand command, CommandHandlerDelegate next, CancellationToken cancellationToken)
+        {
+            _log.Add("Before Void Command");
+            await next();
+            _log.Add("After Void Command");
+        }
+    }
+
+    public class TestQueryPipelineBehavior<TQuery, TResult> : IQueryPipelineBehavior<TQuery, TResult>
+        where TQuery : IQuery<TResult>
+    {
+        private readonly List<string> _log;
+
+        public TestQueryPipelineBehavior(List<string> log)
+        {
+            _log = log;
+        }
+
+        public async Task<TResult> Handle(TQuery query, QueryHandlerDelegate<TResult> next, CancellationToken cancellationToken)
+        {
+            _log.Add("Before Query");
+            var result = await next();
+            _log.Add("After Query");
+            return result;
+        }
+    }
+
+    #endregion
+
+    public class MediatorPipelineTests
+    {
+        [Fact]
+        public async Task SendAsync_WithPipelineBehavior_ShouldExecuteBehaviorAndHandler()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddTransient<ICommandHandler<LoggedCommand, string>, LoggedCommandHandler>();
+            services.AddTransient<ICommandPipelineBehavior<LoggedCommand, string>>(sp => 
+                new TestCommandPipelineBehavior<LoggedCommand, string>(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            var command = new LoggedCommand { Input = "Test" };
+
+            // Act
+            var result = await mediator.SendAsync(command);
+
+            // Assert
+            Assert.Equal("Processed: Test", result);
+            Assert.Equal(2, log.Count);
+            Assert.Equal("Before Command", log[0]);
+            Assert.Equal("After Command", log[1]);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithVoidCommandAndPipelineBehavior_ShouldExecuteBehaviorAndHandler()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddSingleton<LoggedVoidCommandHandler>();
+            services.AddTransient<ICommandHandler<LoggedVoidCommand>>(sp => 
+                sp.GetRequiredService<LoggedVoidCommandHandler>());
+            services.AddTransient<ICommandPipelineBehavior<LoggedVoidCommand>>(sp => 
+                new TestVoidCommandPipelineBehavior<LoggedVoidCommand>(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+            var handler = provider.GetRequiredService<LoggedVoidCommandHandler>();
+
+            var command = new LoggedVoidCommand { Input = "VoidTest" };
+
+            // Act
+            await mediator.SendAsync(command);
+
+            // Assert
+            Assert.Equal(2, log.Count);
+            Assert.Equal("Before Void Command", log[0]);
+            Assert.Equal("After Void Command", log[1]);
+            Assert.Single(handler.ExecutionLog);
+            Assert.Equal("Handler: VoidTest", handler.ExecutionLog[0]);
+        }
+
+        [Fact]
+        public async Task QueryAsync_WithPipelineBehavior_ShouldExecuteBehaviorAndHandler()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddTransient<IQueryHandler<LoggedQuery, string>, LoggedQueryHandler>();
+            services.AddTransient<IQueryPipelineBehavior<LoggedQuery, string>>(sp => 
+                new TestQueryPipelineBehavior<LoggedQuery, string>(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            var query = new LoggedQuery { Input = "QueryTest" };
+
+            // Act
+            var result = await mediator.QueryAsync(query);
+
+            // Assert
+            Assert.Equal("Query Result: QueryTest", result);
+            Assert.Equal(2, log.Count);
+            Assert.Equal("Before Query", log[0]);
+            Assert.Equal("After Query", log[1]);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithMultiplePipelineBehaviors_ShouldExecuteInCorrectOrder()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddTransient<ICommandHandler<LoggedCommand, string>, LoggedCommandHandler>();
+            
+            // Register two behaviors - they execute in reverse registration order (like middleware)
+            services.AddTransient<ICommandPipelineBehavior<LoggedCommand, string>>(sp => 
+                new NamedCommandPipelineBehavior<LoggedCommand, string>("First", log));
+            services.AddTransient<ICommandPipelineBehavior<LoggedCommand, string>>(sp => 
+                new NamedCommandPipelineBehavior<LoggedCommand, string>("Second", log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            var command = new LoggedCommand { Input = "Test" };
+
+            // Act
+            var result = await mediator.SendAsync(command);
+
+            // Assert
+            Assert.Equal("Processed: Test", result);
+            Assert.Equal(4, log.Count);
+            // Behaviors are applied in reverse registration order, then executed outside-in
+            // Registration: First, Second -> Applied in reverse: Second wraps First
+            // Execution: First is innermost, Second is outermost
+            Assert.Equal("Before First", log[0]);
+            Assert.Equal("Before Second", log[1]);
+            Assert.Equal("After Second", log[2]);
+            Assert.Equal("After First", log[3]);
+        }
+    }
+
+    /// <summary>
+    /// A named pipeline behavior for testing execution order
+    /// </summary>
+    public class NamedCommandPipelineBehavior<TCommand, TResult> : ICommandPipelineBehavior<TCommand, TResult>
+        where TCommand : ICommand<TResult>
+    {
+        private readonly string _name;
+        private readonly List<string> _log;
+
+        public NamedCommandPipelineBehavior(string name, List<string> log)
+        {
+            _name = name;
+            _log = log;
+        }
+
+        public async Task<TResult> Handle(TCommand command, CommandHandlerDelegate<TResult> next, CancellationToken cancellationToken)
+        {
+            _log.Add($"Before {_name}");
+            var result = await next();
+            _log.Add($"After {_name}");
+            return result;
+        }
+    }
+}

--- a/src/Cortex.Tests/Mediator/Tests/MediatorTests.cs
+++ b/src/Cortex.Tests/Mediator/Tests/MediatorTests.cs
@@ -1,0 +1,324 @@
+using Cortex.Mediator;
+using Cortex.Mediator.Commands;
+using Cortex.Mediator.Queries;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cortex.Tests.Mediator.Tests
+{
+    #region Test Commands and Queries
+
+    public class CreateUserCommand : ICommand<Guid>
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+    }
+
+    public class CreateUserCommandHandler : ICommandHandler<CreateUserCommand, Guid>
+    {
+        public Task<Guid> Handle(CreateUserCommand command, CancellationToken cancellationToken)
+        {
+            // Simulate creating a user and returning a new Guid
+            return Task.FromResult(Guid.NewGuid());
+        }
+    }
+
+    public class DeleteUserCommand : ICommand
+    {
+        public Guid UserId { get; set; }
+    }
+
+    public class DeleteUserCommandHandler : ICommandHandler<DeleteUserCommand>
+    {
+        public bool WasHandled { get; private set; }
+
+        public Task Handle(DeleteUserCommand command, CancellationToken cancellationToken)
+        {
+            WasHandled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    public class GetUserQuery : IQuery<UserDto>
+    {
+        public Guid UserId { get; set; }
+    }
+
+    public class UserDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+    }
+
+    public class GetUserQueryHandler : IQueryHandler<GetUserQuery, UserDto>
+    {
+        public Task<UserDto> Handle(GetUserQuery query, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new UserDto
+            {
+                Id = query.UserId,
+                Name = "Test User",
+                Email = "test@example.com"
+            });
+        }
+    }
+
+    public class GetUsersCountQuery : IQuery<int>
+    {
+    }
+
+    public class GetUsersCountQueryHandler : IQueryHandler<GetUsersCountQuery, int>
+    {
+        public Task<int> Handle(GetUsersCountQuery query, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(42);
+        }
+    }
+
+    #endregion
+
+    public class MediatorTests
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IMediator _mediator;
+
+        public MediatorTests()
+        {
+            var services = new ServiceCollection();
+            
+            // Register the mediator
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            
+            // Register command handlers
+            services.AddTransient<ICommandHandler<CreateUserCommand, Guid>, CreateUserCommandHandler>();
+            services.AddSingleton<DeleteUserCommandHandler>();
+            services.AddTransient<ICommandHandler<DeleteUserCommand>>(sp => sp.GetRequiredService<DeleteUserCommandHandler>());
+            
+            // Register query handlers
+            services.AddTransient<IQueryHandler<GetUserQuery, UserDto>, GetUserQueryHandler>();
+            services.AddTransient<IQueryHandler<GetUsersCountQuery, int>, GetUsersCountQueryHandler>();
+
+            _serviceProvider = services.BuildServiceProvider();
+            _mediator = _serviceProvider.GetRequiredService<IMediator>();
+        }
+
+        #region SendAsync Extension Method Tests (Commands with Result)
+
+        [Fact]
+        public async Task SendAsync_WithCommandThatReturnsValue_ShouldReturnResult()
+        {
+            // Arrange
+            var command = new CreateUserCommand { Name = "John Doe", Email = "john@example.com" };
+
+            // Act - Using the new simplified API via extension method
+            var result = await _mediator.SendAsync(command);
+
+            // Assert
+            Assert.NotEqual(Guid.Empty, result);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithCommandThatReturnsValue_TypeIsInferredCorrectly()
+        {
+            // Arrange
+            var command = new CreateUserCommand { Name = "Jane Doe", Email = "jane@example.com" };
+
+            // Act - The result type (Guid) is inferred from the command
+            Guid result = await _mediator.SendAsync(command);
+
+            // Assert - This test verifies type inference works correctly at compile time
+            Assert.IsType<Guid>(result);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithNullCommand_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            ICommand<Guid> command = null!;
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _mediator.SendAsync(command));
+        }
+
+        #endregion
+
+        #region SendAsync Extension Method Tests (Void Commands)
+
+        [Fact]
+        public async Task SendAsync_WithVoidCommand_ShouldExecuteHandler()
+        {
+            // Arrange
+            var command = new DeleteUserCommand { UserId = Guid.NewGuid() };
+            var handler = _serviceProvider.GetRequiredService<DeleteUserCommandHandler>();
+
+            // Act - Using the new simplified API
+            await _mediator.SendAsync(command);
+
+            // Assert
+            Assert.True(handler.WasHandled);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithVoidNullCommand_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            ICommand command = null!;
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _mediator.SendAsync(command));
+        }
+
+        #endregion
+
+        #region QueryAsync Extension Method Tests
+
+        [Fact]
+        public async Task QueryAsync_WithQuery_ShouldReturnResult()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var query = new GetUserQuery { UserId = userId };
+
+            // Act - Using the new simplified API
+            var result = await _mediator.QueryAsync(query);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(userId, result.Id);
+            Assert.Equal("Test User", result.Name);
+            Assert.Equal("test@example.com", result.Email);
+        }
+
+        [Fact]
+        public async Task QueryAsync_WithQuery_TypeIsInferredCorrectly()
+        {
+            // Arrange
+            var query = new GetUsersCountQuery();
+
+            // Act - The result type (int) is inferred from the query
+            int result = await _mediator.QueryAsync(query);
+
+            // Assert - This test verifies type inference works correctly
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
+        public async Task QueryAsync_WithNullQuery_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            IQuery<UserDto> query = null!;
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _mediator.QueryAsync(query));
+        }
+
+        #endregion
+
+        #region Direct Interface Method Tests (Non-extension)
+
+        [Fact]
+        public async Task SendCommandAsync_WithInferredType_ShouldReturnResult()
+        {
+            // Arrange
+            ICommand<Guid> command = new CreateUserCommand { Name = "Test", Email = "test@test.com" };
+
+            // Act - Using the new interface method directly
+            var result = await _mediator.SendCommandAsync(command);
+
+            // Assert
+            Assert.NotEqual(Guid.Empty, result);
+        }
+
+        [Fact]
+        public async Task SendCommandAsync_WithVoidInferredType_ShouldExecute()
+        {
+            // Arrange
+            ICommand command = new DeleteUserCommand { UserId = Guid.NewGuid() };
+            var handler = _serviceProvider.GetRequiredService<DeleteUserCommandHandler>();
+
+            // Act - Using the new interface method directly
+            await _mediator.SendCommandAsync(command);
+
+            // Assert
+            Assert.True(handler.WasHandled);
+        }
+
+        [Fact]
+        public async Task SendQueryAsync_WithInferredType_ShouldReturnResult()
+        {
+            // Arrange
+            IQuery<int> query = new GetUsersCountQuery();
+
+            // Act - Using the new interface method directly
+            var result = await _mediator.SendQueryAsync(query);
+
+            // Assert
+            Assert.Equal(42, result);
+        }
+
+        #endregion
+
+        #region Backward Compatibility Tests
+
+        [Fact]
+        public async Task SendCommandAsync_WithExplicitTypeParameters_ShouldStillWork()
+        {
+            // Arrange
+            var command = new CreateUserCommand { Name = "Legacy", Email = "legacy@test.com" };
+
+            // Act - Using the original API with explicit type parameters
+            var result = await _mediator.SendCommandAsync<CreateUserCommand, Guid>(command);
+
+            // Assert
+            Assert.NotEqual(Guid.Empty, result);
+        }
+
+        [Fact]
+        public async Task SendQueryAsync_WithExplicitTypeParameters_ShouldStillWork()
+        {
+            // Arrange
+            var query = new GetUserQuery { UserId = Guid.NewGuid() };
+
+            // Act - Using the original API with explicit type parameters
+            var result = await _mediator.SendQueryAsync<GetUserQuery, UserDto>(query);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Test User", result.Name);
+        }
+
+        #endregion
+
+        #region Cancellation Token Tests
+
+        [Fact]
+        public async Task SendAsync_WithCancellationToken_ShouldPassTokenToHandler()
+        {
+            // Arrange
+            var command = new CreateUserCommand { Name = "Test", Email = "test@test.com" };
+            using var cts = new CancellationTokenSource();
+
+            // Act - The token should be passed through
+            var result = await _mediator.SendAsync(command, cts.Token);
+
+            // Assert
+            Assert.NotEqual(Guid.Empty, result);
+        }
+
+        [Fact]
+        public async Task QueryAsync_WithCancellationToken_ShouldPassTokenToHandler()
+        {
+            // Arrange
+            var query = new GetUsersCountQuery();
+            using var cts = new CancellationTokenSource();
+
+            // Act - The token should be passed through
+            var result = await _mediator.QueryAsync(query, cts.Token);
+
+            // Assert
+            Assert.Equal(42, result);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Add overloads and extension methods to IMediator for sending commands and queries with automatic type inference, reducing the need for explicit type parameters. Update documentation to recommend the new API, and add comprehensive tests to ensure correctness and backward compatibility. Implementation uses reflection and caching for efficient dispatch.