### PR TITLE
Add OneOf/AnyOf (up to 8) and Result types with tests

### DIFF
--- a/src/Cortex.Tests/Cortex.Tests.csproj
+++ b/src/Cortex.Tests/Cortex.Tests.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\Cortex.Streams.Mediator\Cortex.Streams.Mediator.csproj" />
     <ProjectReference Include="..\Cortex.Streams\Cortex.Streams.csproj" />
     <ProjectReference Include="..\Cortex.Telemetry\Cortex.Telemetry.csproj" />
+    <ProjectReference Include="..\Cortex.Types\Cortex.Types.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cortex.Tests/Types/Tests/AnyOfTests.cs
+++ b/src/Cortex.Tests/Types/Tests/AnyOfTests.cs
@@ -1,0 +1,649 @@
+using Cortex.Types;
+
+namespace Cortex.Tests.Types.Tests
+{
+    public class AnyOfTests
+    {
+        #region AnyOf<T1, T2> Tests
+
+        [Fact]
+        public void AnyOf2_ImplicitConversion_FromT1_SetsCorrectTypeIndex()
+        {
+            AnyOf<int, string> value = 42;
+
+            Assert.Contains(0, value.TypeIndices);
+            Assert.Equal(42, value.Value);
+        }
+
+        [Fact]
+        public void AnyOf2_ImplicitConversion_FromT2_SetsCorrectTypeIndex()
+        {
+            AnyOf<int, string> value = "hello";
+
+            Assert.Contains(1, value.TypeIndices);
+            Assert.Equal("hello", value.Value);
+        }
+
+        [Fact]
+        public void AnyOf2_Is_ReturnsTrue_WhenTypeMatches()
+        {
+            AnyOf<int, string> value = 42;
+
+            Assert.True(value.Is<int>());
+            Assert.False(value.Is<string>());
+        }
+
+        [Fact]
+        public void AnyOf2_As_ReturnsValue_WhenTypeMatches()
+        {
+            AnyOf<int, string> value = 42;
+
+            Assert.Equal(42, value.As<int>());
+        }
+
+        [Fact]
+        public void AnyOf2_As_ThrowsInvalidCastException_WhenTypeMismatch()
+        {
+            AnyOf<int, string> value = 42;
+
+            Assert.Throws<InvalidCastException>(() => value.As<string>());
+        }
+
+        [Fact]
+        public void AnyOf2_TryGet_ReturnsTrue_WhenTypeMatches()
+        {
+            AnyOf<int, string> value = 42;
+
+            Assert.True(value.TryGet(out int result));
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
+        public void AnyOf2_TryGet_ReturnsFalse_WhenTypeMismatch()
+        {
+            AnyOf<int, string> value = 42;
+
+            Assert.False(value.TryGet(out string? result));
+        }
+
+        [Fact]
+        public void AnyOf2_Match_ExecutesCorrectHandler()
+        {
+            AnyOf<int, string> intValue = 42;
+            AnyOf<int, string> stringValue = "hello";
+
+            var intResult = intValue.Match(
+                i => $"int: {i}",
+                s => $"string: {s}");
+
+            var stringResult = stringValue.Match(
+                i => $"int: {i}",
+                s => $"string: {s}");
+
+            Assert.Equal("int: 42", intResult);
+            Assert.Equal("string: hello", stringResult);
+        }
+
+        [Fact]
+        public void AnyOf2_Switch_ExecutesCorrectAction()
+        {
+            AnyOf<int, string> value = 42;
+            int? capturedInt = null;
+            string? capturedString = null;
+
+            value.Switch(
+                i => capturedInt = i,
+                s => capturedString = s);
+
+            Assert.Equal(42, capturedInt);
+            Assert.Null(capturedString);
+        }
+
+        [Fact]
+        public void AnyOf2_GetMatchingTypes_ReturnsMatchingTypes()
+        {
+            AnyOf<int, string> value = 42;
+
+            var matchingTypes = value.GetMatchingTypes().ToList();
+
+            Assert.Single(matchingTypes);
+            Assert.Contains(typeof(int), matchingTypes);
+        }
+
+        [Fact]
+        public void AnyOf2_Equals_ReturnsTrue_ForSameValues()
+        {
+            AnyOf<int, string> value1 = 42;
+            AnyOf<int, string> value2 = 42;
+
+            Assert.Equal(value1, value2);
+            Assert.True(value1 == value2);
+            Assert.False(value1 != value2);
+        }
+
+        [Fact]
+        public void AnyOf2_ToString_ReturnsValueString()
+        {
+            AnyOf<int, string> value = 42;
+
+            Assert.Equal("42", value.ToString());
+        }
+
+        #endregion
+
+        #region AnyOf<T1, T2, T3> Tests
+
+        [Fact]
+        public void AnyOf3_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            AnyOf<int, string, double> intVal = 42;
+            AnyOf<int, string, double> strVal = "hello";
+            AnyOf<int, string, double> dblVal = 3.14;
+
+            Assert.Contains(0, intVal.TypeIndices);
+            Assert.Contains(1, strVal.TypeIndices);
+            Assert.Contains(2, dblVal.TypeIndices);
+        }
+
+        [Fact]
+        public void AnyOf3_Match_ExecutesCorrectHandler()
+        {
+            AnyOf<int, string, double> value = 3.14;
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double");
+
+            Assert.Equal("double", result);
+        }
+
+        [Fact]
+        public void AnyOf3_Switch_ExecutesCorrectAction()
+        {
+            AnyOf<int, string, double> value = "hello";
+            string? captured = null;
+
+            value.Switch(
+                i => { },
+                s => captured = s,
+                d => { });
+
+            Assert.Equal("hello", captured);
+        }
+
+        [Fact]
+        public void AnyOf3_GetMatchingTypes_ReturnsMatchingTypes()
+        {
+            AnyOf<int, string, double> value = 3.14;
+
+            var matchingTypes = value.GetMatchingTypes().ToList();
+
+            Assert.Single(matchingTypes);
+            Assert.Contains(typeof(double), matchingTypes);
+        }
+
+        #endregion
+
+        #region AnyOf<T1, T2, T3, T4> Tests
+
+        [Fact]
+        public void AnyOf4_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            AnyOf<int, string, double, bool> val1 = 42;
+            AnyOf<int, string, double, bool> val2 = "hello";
+            AnyOf<int, string, double, bool> val3 = 3.14;
+            AnyOf<int, string, double, bool> val4 = true;
+
+            Assert.Contains(0, val1.TypeIndices);
+            Assert.Contains(1, val2.TypeIndices);
+            Assert.Contains(2, val3.TypeIndices);
+            Assert.Contains(3, val4.TypeIndices);
+        }
+
+        [Fact]
+        public void AnyOf4_Match_ExecutesCorrectHandler()
+        {
+            AnyOf<int, string, double, bool> value = true;
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double",
+                b => "bool");
+
+            Assert.Equal("bool", result);
+        }
+
+        [Fact]
+        public void AnyOf4_GetMatchingTypes_ReturnsMatchingTypes()
+        {
+            AnyOf<int, string, double, bool> value = true;
+
+            var matchingTypes = value.GetMatchingTypes().ToList();
+
+            Assert.Single(matchingTypes);
+            Assert.Contains(typeof(bool), matchingTypes);
+        }
+
+        #endregion
+
+        #region AnyOf<T1, T2, T3, T4, T5> Tests
+
+        [Fact]
+        public void AnyOf5_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            AnyOf<int, string, double, bool, char> val1 = 42;
+            AnyOf<int, string, double, bool, char> val2 = "hello";
+            AnyOf<int, string, double, bool, char> val3 = 3.14;
+            AnyOf<int, string, double, bool, char> val4 = true;
+            AnyOf<int, string, double, bool, char> val5 = 'x';
+
+            Assert.Contains(0, val1.TypeIndices);
+            Assert.Contains(1, val2.TypeIndices);
+            Assert.Contains(2, val3.TypeIndices);
+            Assert.Contains(3, val4.TypeIndices);
+            Assert.Contains(4, val5.TypeIndices);
+        }
+
+        [Fact]
+        public void AnyOf5_Match_ExecutesCorrectHandler()
+        {
+            AnyOf<int, string, double, bool, char> value = 'x';
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double",
+                b => "bool",
+                c => "char");
+
+            Assert.Equal("char", result);
+        }
+
+        [Fact]
+        public void AnyOf5_Switch_ExecutesCorrectAction()
+        {
+            AnyOf<int, string, double, bool, char> value = 'x';
+            char? captured = null;
+
+            value.Switch(
+                i => { },
+                s => { },
+                d => { },
+                b => { },
+                c => captured = c);
+
+            Assert.Equal('x', captured);
+        }
+
+        [Fact]
+        public void AnyOf5_TryGet_WorksCorrectly()
+        {
+            AnyOf<int, string, double, bool, char> value = 3.14;
+
+            Assert.True(value.TryGet(out double d));
+            Assert.Equal(3.14, d);
+            Assert.False(value.TryGet(out int _));
+        }
+
+        [Fact]
+        public void AnyOf5_GetMatchingTypes_ReturnsMatchingTypes()
+        {
+            AnyOf<int, string, double, bool, char> value = 'x';
+
+            var matchingTypes = value.GetMatchingTypes().ToList();
+
+            Assert.Single(matchingTypes);
+            Assert.Contains(typeof(char), matchingTypes);
+        }
+
+        [Fact]
+        public void AnyOf5_Equals_WorksCorrectly()
+        {
+            AnyOf<int, string, double, bool, char> val1 = 'x';
+            AnyOf<int, string, double, bool, char> val2 = 'x';
+            AnyOf<int, string, double, bool, char> val3 = 'y';
+
+            Assert.Equal(val1, val2);
+            Assert.NotEqual(val1, val3);
+        }
+
+        #endregion
+
+        #region AnyOf<T1, T2, T3, T4, T5, T6> Tests
+
+        [Fact]
+        public void AnyOf6_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            AnyOf<int, string, double, bool, char, long> val1 = 42;
+            AnyOf<int, string, double, bool, char, long> val2 = "hello";
+            AnyOf<int, string, double, bool, char, long> val3 = 3.14;
+            AnyOf<int, string, double, bool, char, long> val4 = true;
+            AnyOf<int, string, double, bool, char, long> val5 = 'x';
+            AnyOf<int, string, double, bool, char, long> val6 = 100L;
+
+            Assert.Contains(0, val1.TypeIndices);
+            Assert.Contains(1, val2.TypeIndices);
+            Assert.Contains(2, val3.TypeIndices);
+            Assert.Contains(3, val4.TypeIndices);
+            Assert.Contains(4, val5.TypeIndices);
+            Assert.Contains(5, val6.TypeIndices);
+        }
+
+        [Fact]
+        public void AnyOf6_Match_ExecutesCorrectHandler()
+        {
+            AnyOf<int, string, double, bool, char, long> value = 100L;
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double",
+                b => "bool",
+                c => "char",
+                l => "long");
+
+            Assert.Equal("long", result);
+        }
+
+        [Fact]
+        public void AnyOf6_Switch_ExecutesCorrectAction()
+        {
+            AnyOf<int, string, double, bool, char, long> value = 100L;
+            long? captured = null;
+
+            value.Switch(
+                i => { },
+                s => { },
+                d => { },
+                b => { },
+                c => { },
+                l => captured = l);
+
+            Assert.Equal(100L, captured);
+        }
+
+        [Fact]
+        public void AnyOf6_GetMatchingTypes_ReturnsMatchingTypes()
+        {
+            AnyOf<int, string, double, bool, char, long> value = 100L;
+
+            var matchingTypes = value.GetMatchingTypes().ToList();
+
+            Assert.Single(matchingTypes);
+            Assert.Contains(typeof(long), matchingTypes);
+        }
+
+        #endregion
+
+        #region AnyOf<T1, T2, T3, T4, T5, T6, T7> Tests
+
+        [Fact]
+        public void AnyOf7_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            AnyOf<int, string, double, bool, char, long, float> val1 = 42;
+            AnyOf<int, string, double, bool, char, long, float> val2 = "hello";
+            AnyOf<int, string, double, bool, char, long, float> val3 = 3.14;
+            AnyOf<int, string, double, bool, char, long, float> val4 = true;
+            AnyOf<int, string, double, bool, char, long, float> val5 = 'x';
+            AnyOf<int, string, double, bool, char, long, float> val6 = 100L;
+            AnyOf<int, string, double, bool, char, long, float> val7 = 1.5f;
+
+            Assert.Contains(0, val1.TypeIndices);
+            Assert.Contains(1, val2.TypeIndices);
+            Assert.Contains(2, val3.TypeIndices);
+            Assert.Contains(3, val4.TypeIndices);
+            Assert.Contains(4, val5.TypeIndices);
+            Assert.Contains(5, val6.TypeIndices);
+            Assert.Contains(6, val7.TypeIndices);
+        }
+
+        [Fact]
+        public void AnyOf7_Match_ExecutesCorrectHandler()
+        {
+            AnyOf<int, string, double, bool, char, long, float> value = 1.5f;
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double",
+                b => "bool",
+                c => "char",
+                l => "long",
+                f => "float");
+
+            Assert.Equal("float", result);
+        }
+
+        [Fact]
+        public void AnyOf7_Switch_ExecutesCorrectAction()
+        {
+            AnyOf<int, string, double, bool, char, long, float> value = 1.5f;
+            float? captured = null;
+
+            value.Switch(
+                i => { },
+                s => { },
+                d => { },
+                b => { },
+                c => { },
+                l => { },
+                f => captured = f);
+
+            Assert.Equal(1.5f, captured);
+        }
+
+        [Fact]
+        public void AnyOf7_GetMatchingTypes_ReturnsMatchingTypes()
+        {
+            AnyOf<int, string, double, bool, char, long, float> value = 1.5f;
+
+            var matchingTypes = value.GetMatchingTypes().ToList();
+
+            Assert.Single(matchingTypes);
+            Assert.Contains(typeof(float), matchingTypes);
+        }
+
+        [Fact]
+        public void AnyOf7_Equality_WorksCorrectly()
+        {
+            AnyOf<int, string, double, bool, char, long, float> val1 = 1.5f;
+            AnyOf<int, string, double, bool, char, long, float> val2 = 1.5f;
+
+            Assert.True(val1 == val2);
+            Assert.False(val1 != val2);
+        }
+
+        #endregion
+
+        #region AnyOf<T1, T2, T3, T4, T5, T6, T7, T8> Tests
+
+        [Fact]
+        public void AnyOf8_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            AnyOf<int, string, double, bool, char, long, float, decimal> val1 = 42;
+            AnyOf<int, string, double, bool, char, long, float, decimal> val2 = "hello";
+            AnyOf<int, string, double, bool, char, long, float, decimal> val3 = 3.14;
+            AnyOf<int, string, double, bool, char, long, float, decimal> val4 = true;
+            AnyOf<int, string, double, bool, char, long, float, decimal> val5 = 'x';
+            AnyOf<int, string, double, bool, char, long, float, decimal> val6 = 100L;
+            AnyOf<int, string, double, bool, char, long, float, decimal> val7 = 1.5f;
+            AnyOf<int, string, double, bool, char, long, float, decimal> val8 = 99.99m;
+
+            Assert.Contains(0, val1.TypeIndices);
+            Assert.Contains(1, val2.TypeIndices);
+            Assert.Contains(2, val3.TypeIndices);
+            Assert.Contains(3, val4.TypeIndices);
+            Assert.Contains(4, val5.TypeIndices);
+            Assert.Contains(5, val6.TypeIndices);
+            Assert.Contains(6, val7.TypeIndices);
+            Assert.Contains(7, val8.TypeIndices);
+        }
+
+        [Fact]
+        public void AnyOf8_Match_ExecutesCorrectHandler()
+        {
+            AnyOf<int, string, double, bool, char, long, float, decimal> value = 99.99m;
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double",
+                b => "bool",
+                c => "char",
+                l => "long",
+                f => "float",
+                m => "decimal");
+
+            Assert.Equal("decimal", result);
+        }
+
+        [Fact]
+        public void AnyOf8_Switch_ExecutesCorrectAction()
+        {
+            AnyOf<int, string, double, bool, char, long, float, decimal> value = 99.99m;
+            decimal? captured = null;
+
+            value.Switch(
+                i => { },
+                s => { },
+                d => { },
+                b => { },
+                c => { },
+                l => { },
+                f => { },
+                m => captured = m);
+
+            Assert.Equal(99.99m, captured);
+        }
+
+        [Fact]
+        public void AnyOf8_Is_WorksForAllTypes()
+        {
+            AnyOf<int, string, double, bool, char, long, float, decimal> value = 99.99m;
+
+            Assert.False(value.Is<int>());
+            Assert.False(value.Is<string>());
+            Assert.False(value.Is<double>());
+            Assert.False(value.Is<bool>());
+            Assert.False(value.Is<char>());
+            Assert.False(value.Is<long>());
+            Assert.False(value.Is<float>());
+            Assert.True(value.Is<decimal>());
+        }
+
+        [Fact]
+        public void AnyOf8_As_WorksCorrectly()
+        {
+            AnyOf<int, string, double, bool, char, long, float, decimal> value = 99.99m;
+
+            Assert.Equal(99.99m, value.As<decimal>());
+            Assert.Throws<InvalidCastException>(() => value.As<int>());
+        }
+
+        [Fact]
+        public void AnyOf8_TryGet_WorksCorrectly()
+        {
+            AnyOf<int, string, double, bool, char, long, float, decimal> value = 99.99m;
+
+            Assert.True(value.TryGet(out decimal d));
+            Assert.Equal(99.99m, d);
+            Assert.False(value.TryGet(out int _));
+        }
+
+        [Fact]
+        public void AnyOf8_GetMatchingTypes_ReturnsMatchingTypes()
+        {
+            AnyOf<int, string, double, bool, char, long, float, decimal> value = 99.99m;
+
+            var matchingTypes = value.GetMatchingTypes().ToList();
+
+            Assert.Single(matchingTypes);
+            Assert.Contains(typeof(decimal), matchingTypes);
+        }
+
+        [Fact]
+        public void AnyOf8_Equality_WorksCorrectly()
+        {
+            AnyOf<int, string, double, bool, char, long, float, decimal> val1 = 99.99m;
+            AnyOf<int, string, double, bool, char, long, float, decimal> val2 = 99.99m;
+            AnyOf<int, string, double, bool, char, long, float, decimal> val3 = 100m;
+
+            Assert.True(val1 == val2);
+            Assert.False(val1 != val2);
+            Assert.True(val1 != val3);
+        }
+
+        [Fact]
+        public void AnyOf8_ToString_ReturnsValueString()
+        {
+            AnyOf<int, string, double, bool, char, long, float, decimal> value = "hello";
+
+            Assert.Equal("hello", value.ToString());
+        }
+
+        #endregion
+
+        #region IAnyOf Interface Tests
+
+        [Fact]
+        public void AllAnyOfTypes_ImplementIAnyOf()
+        {
+            IAnyOf anyOf2 = (AnyOf<int, string>)42;
+            IAnyOf anyOf3 = (AnyOf<int, string, double>)42;
+            IAnyOf anyOf4 = (AnyOf<int, string, double, bool>)42;
+            IAnyOf anyOf5 = (AnyOf<int, string, double, bool, char>)42;
+            IAnyOf anyOf6 = (AnyOf<int, string, double, bool, char, long>)42;
+            IAnyOf anyOf7 = (AnyOf<int, string, double, bool, char, long, float>)42;
+            IAnyOf anyOf8 = (AnyOf<int, string, double, bool, char, long, float, decimal>)42;
+
+            Assert.Equal(42, anyOf2.Value);
+            Assert.Contains(0, anyOf2.TypeIndices);
+
+            Assert.Equal(42, anyOf3.Value);
+            Assert.Equal(42, anyOf4.Value);
+            Assert.Equal(42, anyOf5.Value);
+            Assert.Equal(42, anyOf6.Value);
+            Assert.Equal(42, anyOf7.Value);
+            Assert.Equal(42, anyOf8.Value);
+        }
+
+        #endregion
+
+        #region Inheritance/Polymorphism Tests
+
+        [Fact]
+        public void AnyOf_GetMatchingTypes_IncludesBaseTypes()
+        {
+            // ArgumentException derives from Exception
+            AnyOf<Exception, string> value = new ArgumentException("test");
+
+            var matchingTypes = value.GetMatchingTypes().ToList();
+
+            // Both Exception (base) and the actual type should match
+            Assert.Contains(typeof(Exception), matchingTypes);
+        }
+
+        [Fact]
+        public void AnyOf_Is_WorksWithDerivedTypes()
+        {
+            AnyOf<Exception, string> value = new ArgumentException("test");
+
+            Assert.True(value.Is<Exception>());
+            Assert.True(value.Is<ArgumentException>());
+            Assert.False(value.Is<InvalidOperationException>());
+        }
+
+        [Fact]
+        public void AnyOf_As_WorksWithDerivedTypes()
+        {
+            AnyOf<Exception, string> value = new ArgumentException("test");
+
+            Assert.IsType<ArgumentException>(value.As<Exception>());
+            Assert.IsType<ArgumentException>(value.As<ArgumentException>());
+        }
+
+        #endregion
+    }
+}

--- a/src/Cortex.Tests/Types/Tests/OneOfTests.cs
+++ b/src/Cortex.Tests/Types/Tests/OneOfTests.cs
@@ -1,0 +1,571 @@
+using Cortex.Types;
+
+namespace Cortex.Tests.Types.Tests
+{
+    public class OneOfTests
+    {
+        #region OneOf<T1, T2> Tests
+
+        [Fact]
+        public void OneOf2_ImplicitConversion_FromT1_SetsCorrectTypeIndex()
+        {
+            OneOf<int, string> value = 42;
+
+            Assert.Equal(0, value.TypeIndex);
+            Assert.Equal(42, value.Value);
+        }
+
+        [Fact]
+        public void OneOf2_ImplicitConversion_FromT2_SetsCorrectTypeIndex()
+        {
+            OneOf<int, string> value = "hello";
+
+            Assert.Equal(1, value.TypeIndex);
+            Assert.Equal("hello", value.Value);
+        }
+
+        [Fact]
+        public void OneOf2_Is_ReturnsTrue_WhenTypeMatches()
+        {
+            OneOf<int, string> value = 42;
+
+            Assert.True(value.Is<int>());
+            Assert.False(value.Is<string>());
+        }
+
+        [Fact]
+        public void OneOf2_As_ReturnsValue_WhenTypeMatches()
+        {
+            OneOf<int, string> value = 42;
+
+            Assert.Equal(42, value.As<int>());
+        }
+
+        [Fact]
+        public void OneOf2_As_ThrowsInvalidCastException_WhenTypeMismatch()
+        {
+            OneOf<int, string> value = 42;
+
+            Assert.Throws<InvalidCastException>(() => value.As<string>());
+        }
+
+        [Fact]
+        public void OneOf2_TryGet_ReturnsTrue_WhenTypeMatches()
+        {
+            OneOf<int, string> value = 42;
+
+            Assert.True(value.TryGet(out int result));
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
+        public void OneOf2_TryGet_ReturnsFalse_WhenTypeMismatch()
+        {
+            OneOf<int, string> value = 42;
+
+            Assert.False(value.TryGet(out string? result));
+        }
+
+        [Fact]
+        public void OneOf2_Match_ExecutesCorrectHandler()
+        {
+            OneOf<int, string> intValue = 42;
+            OneOf<int, string> stringValue = "hello";
+
+            var intResult = intValue.Match(
+                i => $"int: {i}",
+                s => $"string: {s}");
+
+            var stringResult = stringValue.Match(
+                i => $"int: {i}",
+                s => $"string: {s}");
+
+            Assert.Equal("int: 42", intResult);
+            Assert.Equal("string: hello", stringResult);
+        }
+
+        [Fact]
+        public void OneOf2_Switch_ExecutesCorrectAction()
+        {
+            OneOf<int, string> value = 42;
+            int? capturedInt = null;
+            string? capturedString = null;
+
+            value.Switch(
+                i => capturedInt = i,
+                s => capturedString = s);
+
+            Assert.Equal(42, capturedInt);
+            Assert.Null(capturedString);
+        }
+
+        [Fact]
+        public void OneOf2_Equals_ReturnsTrue_ForSameValues()
+        {
+            OneOf<int, string> value1 = 42;
+            OneOf<int, string> value2 = 42;
+
+            Assert.Equal(value1, value2);
+            Assert.True(value1 == value2);
+            Assert.False(value1 != value2);
+        }
+
+        [Fact]
+        public void OneOf2_Equals_ReturnsFalse_ForDifferentValues()
+        {
+            OneOf<int, string> value1 = 42;
+            OneOf<int, string> value2 = "hello";
+
+            Assert.NotEqual(value1, value2);
+        }
+
+        [Fact]
+        public void OneOf2_ToString_ReturnsValueString()
+        {
+            OneOf<int, string> value = 42;
+
+            Assert.Equal("42", value.ToString());
+        }
+
+        #endregion
+
+        #region OneOf<T1, T2, T3> Tests
+
+        [Fact]
+        public void OneOf3_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            OneOf<int, string, double> intVal = 42;
+            OneOf<int, string, double> strVal = "hello";
+            OneOf<int, string, double> dblVal = 3.14;
+
+            Assert.Equal(0, intVal.TypeIndex);
+            Assert.Equal(1, strVal.TypeIndex);
+            Assert.Equal(2, dblVal.TypeIndex);
+        }
+
+        [Fact]
+        public void OneOf3_Match_ExecutesCorrectHandler()
+        {
+            OneOf<int, string, double> value = 3.14;
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double");
+
+            Assert.Equal("double", result);
+        }
+
+        [Fact]
+        public void OneOf3_Switch_ExecutesCorrectAction()
+        {
+            OneOf<int, string, double> value = "hello";
+            string? captured = null;
+
+            value.Switch(
+                i => { },
+                s => captured = s,
+                d => { });
+
+            Assert.Equal("hello", captured);
+        }
+
+        #endregion
+
+        #region OneOf<T1, T2, T3, T4> Tests
+
+        [Fact]
+        public void OneOf4_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            OneOf<int, string, double, bool> val1 = 42;
+            OneOf<int, string, double, bool> val2 = "hello";
+            OneOf<int, string, double, bool> val3 = 3.14;
+            OneOf<int, string, double, bool> val4 = true;
+
+            Assert.Equal(0, val1.TypeIndex);
+            Assert.Equal(1, val2.TypeIndex);
+            Assert.Equal(2, val3.TypeIndex);
+            Assert.Equal(3, val4.TypeIndex);
+        }
+
+        [Fact]
+        public void OneOf4_Match_ExecutesCorrectHandler()
+        {
+            OneOf<int, string, double, bool> value = true;
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double",
+                b => "bool");
+
+            Assert.Equal("bool", result);
+        }
+
+        #endregion
+
+        #region OneOf<T1, T2, T3, T4, T5> Tests
+
+        [Fact]
+        public void OneOf5_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            OneOf<int, string, double, bool, char> val1 = 42;
+            OneOf<int, string, double, bool, char> val2 = "hello";
+            OneOf<int, string, double, bool, char> val3 = 3.14;
+            OneOf<int, string, double, bool, char> val4 = true;
+            OneOf<int, string, double, bool, char> val5 = 'x';
+
+            Assert.Equal(0, val1.TypeIndex);
+            Assert.Equal(1, val2.TypeIndex);
+            Assert.Equal(2, val3.TypeIndex);
+            Assert.Equal(3, val4.TypeIndex);
+            Assert.Equal(4, val5.TypeIndex);
+        }
+
+        [Fact]
+        public void OneOf5_Match_ExecutesCorrectHandler()
+        {
+            OneOf<int, string, double, bool, char> value = 'x';
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double",
+                b => "bool",
+                c => "char");
+
+            Assert.Equal("char", result);
+        }
+
+        [Fact]
+        public void OneOf5_Switch_ExecutesCorrectAction()
+        {
+            OneOf<int, string, double, bool, char> value = 'x';
+            char? captured = null;
+
+            value.Switch(
+                i => { },
+                s => { },
+                d => { },
+                b => { },
+                c => captured = c);
+
+            Assert.Equal('x', captured);
+        }
+
+        [Fact]
+        public void OneOf5_TryGet_WorksCorrectly()
+        {
+            OneOf<int, string, double, bool, char> value = 3.14;
+
+            Assert.True(value.TryGet(out double d));
+            Assert.Equal(3.14, d);
+            Assert.False(value.TryGet(out int _));
+        }
+
+        [Fact]
+        public void OneOf5_Equals_WorksCorrectly()
+        {
+            OneOf<int, string, double, bool, char> val1 = 'x';
+            OneOf<int, string, double, bool, char> val2 = 'x';
+            OneOf<int, string, double, bool, char> val3 = 'y';
+
+            Assert.Equal(val1, val2);
+            Assert.NotEqual(val1, val3);
+        }
+
+        #endregion
+
+        #region OneOf<T1, T2, T3, T4, T5, T6> Tests
+
+        [Fact]
+        public void OneOf6_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            OneOf<int, string, double, bool, char, long> val1 = 42;
+            OneOf<int, string, double, bool, char, long> val2 = "hello";
+            OneOf<int, string, double, bool, char, long> val3 = 3.14;
+            OneOf<int, string, double, bool, char, long> val4 = true;
+            OneOf<int, string, double, bool, char, long> val5 = 'x';
+            OneOf<int, string, double, bool, char, long> val6 = 100L;
+
+            Assert.Equal(0, val1.TypeIndex);
+            Assert.Equal(1, val2.TypeIndex);
+            Assert.Equal(2, val3.TypeIndex);
+            Assert.Equal(3, val4.TypeIndex);
+            Assert.Equal(4, val5.TypeIndex);
+            Assert.Equal(5, val6.TypeIndex);
+        }
+
+        [Fact]
+        public void OneOf6_Match_ExecutesCorrectHandler()
+        {
+            OneOf<int, string, double, bool, char, long> value = 100L;
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double",
+                b => "bool",
+                c => "char",
+                l => "long");
+
+            Assert.Equal("long", result);
+        }
+
+        [Fact]
+        public void OneOf6_Switch_ExecutesCorrectAction()
+        {
+            OneOf<int, string, double, bool, char, long> value = 100L;
+            long? captured = null;
+
+            value.Switch(
+                i => { },
+                s => { },
+                d => { },
+                b => { },
+                c => { },
+                l => captured = l);
+
+            Assert.Equal(100L, captured);
+        }
+
+        #endregion
+
+        #region OneOf<T1, T2, T3, T4, T5, T6, T7> Tests
+
+        [Fact]
+        public void OneOf7_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            OneOf<int, string, double, bool, char, long, float> val1 = 42;
+            OneOf<int, string, double, bool, char, long, float> val2 = "hello";
+            OneOf<int, string, double, bool, char, long, float> val3 = 3.14;
+            OneOf<int, string, double, bool, char, long, float> val4 = true;
+            OneOf<int, string, double, bool, char, long, float> val5 = 'x';
+            OneOf<int, string, double, bool, char, long, float> val6 = 100L;
+            OneOf<int, string, double, bool, char, long, float> val7 = 1.5f;
+
+            Assert.Equal(0, val1.TypeIndex);
+            Assert.Equal(1, val2.TypeIndex);
+            Assert.Equal(2, val3.TypeIndex);
+            Assert.Equal(3, val4.TypeIndex);
+            Assert.Equal(4, val5.TypeIndex);
+            Assert.Equal(5, val6.TypeIndex);
+            Assert.Equal(6, val7.TypeIndex);
+        }
+
+        [Fact]
+        public void OneOf7_Match_ExecutesCorrectHandler()
+        {
+            OneOf<int, string, double, bool, char, long, float> value = 1.5f;
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double",
+                b => "bool",
+                c => "char",
+                l => "long",
+                f => "float");
+
+            Assert.Equal("float", result);
+        }
+
+        [Fact]
+        public void OneOf7_Switch_ExecutesCorrectAction()
+        {
+            OneOf<int, string, double, bool, char, long, float> value = 1.5f;
+            float? captured = null;
+
+            value.Switch(
+                i => { },
+                s => { },
+                d => { },
+                b => { },
+                c => { },
+                l => { },
+                f => captured = f);
+
+            Assert.Equal(1.5f, captured);
+        }
+
+        [Fact]
+        public void OneOf7_Equality_WorksCorrectly()
+        {
+            OneOf<int, string, double, bool, char, long, float> val1 = 1.5f;
+            OneOf<int, string, double, bool, char, long, float> val2 = 1.5f;
+
+            Assert.True(val1 == val2);
+            Assert.False(val1 != val2);
+            Assert.Equal(val1.GetHashCode(), val2.GetHashCode());
+        }
+
+        #endregion
+
+        #region OneOf<T1, T2, T3, T4, T5, T6, T7, T8> Tests
+
+        [Fact]
+        public void OneOf8_ImplicitConversion_FromEachType_SetsCorrectTypeIndex()
+        {
+            OneOf<int, string, double, bool, char, long, float, decimal> val1 = 42;
+            OneOf<int, string, double, bool, char, long, float, decimal> val2 = "hello";
+            OneOf<int, string, double, bool, char, long, float, decimal> val3 = 3.14;
+            OneOf<int, string, double, bool, char, long, float, decimal> val4 = true;
+            OneOf<int, string, double, bool, char, long, float, decimal> val5 = 'x';
+            OneOf<int, string, double, bool, char, long, float, decimal> val6 = 100L;
+            OneOf<int, string, double, bool, char, long, float, decimal> val7 = 1.5f;
+            OneOf<int, string, double, bool, char, long, float, decimal> val8 = 99.99m;
+
+            Assert.Equal(0, val1.TypeIndex);
+            Assert.Equal(1, val2.TypeIndex);
+            Assert.Equal(2, val3.TypeIndex);
+            Assert.Equal(3, val4.TypeIndex);
+            Assert.Equal(4, val5.TypeIndex);
+            Assert.Equal(5, val6.TypeIndex);
+            Assert.Equal(6, val7.TypeIndex);
+            Assert.Equal(7, val8.TypeIndex);
+        }
+
+        [Fact]
+        public void OneOf8_Match_ExecutesCorrectHandler()
+        {
+            OneOf<int, string, double, bool, char, long, float, decimal> value = 99.99m;
+
+            var result = value.Match(
+                i => "int",
+                s => "string",
+                d => "double",
+                b => "bool",
+                c => "char",
+                l => "long",
+                f => "float",
+                m => "decimal");
+
+            Assert.Equal("decimal", result);
+        }
+
+        [Fact]
+        public void OneOf8_Switch_ExecutesCorrectAction()
+        {
+            OneOf<int, string, double, bool, char, long, float, decimal> value = 99.99m;
+            decimal? captured = null;
+
+            value.Switch(
+                i => { },
+                s => { },
+                d => { },
+                b => { },
+                c => { },
+                l => { },
+                f => { },
+                m => captured = m);
+
+            Assert.Equal(99.99m, captured);
+        }
+
+        [Fact]
+        public void OneOf8_Is_WorksForAllTypes()
+        {
+            OneOf<int, string, double, bool, char, long, float, decimal> value = 99.99m;
+
+            Assert.False(value.Is<int>());
+            Assert.False(value.Is<string>());
+            Assert.False(value.Is<double>());
+            Assert.False(value.Is<bool>());
+            Assert.False(value.Is<char>());
+            Assert.False(value.Is<long>());
+            Assert.False(value.Is<float>());
+            Assert.True(value.Is<decimal>());
+        }
+
+        [Fact]
+        public void OneOf8_As_WorksCorrectly()
+        {
+            OneOf<int, string, double, bool, char, long, float, decimal> value = 99.99m;
+
+            Assert.Equal(99.99m, value.As<decimal>());
+            Assert.Throws<InvalidCastException>(() => value.As<int>());
+        }
+
+        [Fact]
+        public void OneOf8_TryGet_WorksCorrectly()
+        {
+            OneOf<int, string, double, bool, char, long, float, decimal> value = 99.99m;
+
+            Assert.True(value.TryGet(out decimal d));
+            Assert.Equal(99.99m, d);
+            Assert.False(value.TryGet(out int _));
+        }
+
+        [Fact]
+        public void OneOf8_Equality_WorksCorrectly()
+        {
+            OneOf<int, string, double, bool, char, long, float, decimal> val1 = 99.99m;
+            OneOf<int, string, double, bool, char, long, float, decimal> val2 = 99.99m;
+            OneOf<int, string, double, bool, char, long, float, decimal> val3 = 100m;
+
+            Assert.True(val1 == val2);
+            Assert.False(val1 != val2);
+            Assert.True(val1 != val3);
+            Assert.Equal(val1.GetHashCode(), val2.GetHashCode());
+        }
+
+        [Fact]
+        public void OneOf8_ToString_ReturnsValueString()
+        {
+            OneOf<int, string, double, bool, char, long, float, decimal> value = "hello";
+
+            Assert.Equal("hello", value.ToString());
+        }
+
+        #endregion
+
+        #region IOneOf Interface Tests
+
+        [Fact]
+        public void AllOneOfTypes_ImplementIOneOf()
+        {
+            IOneOf oneOf2 = (OneOf<int, string>)42;
+            IOneOf oneOf3 = (OneOf<int, string, double>)42;
+            IOneOf oneOf4 = (OneOf<int, string, double, bool>)42;
+            IOneOf oneOf5 = (OneOf<int, string, double, bool, char>)42;
+            IOneOf oneOf6 = (OneOf<int, string, double, bool, char, long>)42;
+            IOneOf oneOf7 = (OneOf<int, string, double, bool, char, long, float>)42;
+            IOneOf oneOf8 = (OneOf<int, string, double, bool, char, long, float, decimal>)42;
+
+            Assert.Equal(42, oneOf2.Value);
+            Assert.Equal(0, oneOf2.TypeIndex);
+
+            Assert.Equal(42, oneOf3.Value);
+            Assert.Equal(42, oneOf4.Value);
+            Assert.Equal(42, oneOf5.Value);
+            Assert.Equal(42, oneOf6.Value);
+            Assert.Equal(42, oneOf7.Value);
+            Assert.Equal(42, oneOf8.Value);
+        }
+
+        #endregion
+
+        #region Inheritance Tests
+
+        [Fact]
+        public void OneOf_Is_WorksWithDerivedTypes()
+        {
+            OneOf<Exception, string> value = new ArgumentException("test");
+
+            Assert.True(value.Is<Exception>());
+            Assert.True(value.Is<ArgumentException>());
+            Assert.False(value.Is<InvalidOperationException>());
+        }
+
+        [Fact]
+        public void OneOf_As_WorksWithDerivedTypes()
+        {
+            OneOf<Exception, string> value = new ArgumentException("test");
+
+            Assert.IsType<ArgumentException>(value.As<Exception>());
+            Assert.IsType<ArgumentException>(value.As<ArgumentException>());
+        }
+
+        #endregion
+    }
+}

--- a/src/Cortex.Tests/Types/Tests/Result2Tests.cs
+++ b/src/Cortex.Tests/Types/Tests/Result2Tests.cs
@@ -1,0 +1,665 @@
+using Cortex.Types;
+
+namespace Cortex.Tests.Types.Tests
+{
+    public class Result2Tests
+    {
+        #region Custom Error Type for Testing
+
+        private record TestError(string Code, string Description);
+
+        #endregion
+
+        #region Creation Tests
+
+        [Fact]
+        public void Success_CreatesSuccessfulResult()
+        {
+            // Act
+            var result = Result<int, TestError>.Success(42);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.False(result.IsFailure);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void Failure_CreatesFailedResult()
+        {
+            // Arrange
+            var error = new TestError("ERR001", "Test error");
+
+            // Act
+            var result = Result<int, TestError>.Failure(error);
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.True(result.IsFailure);
+            Assert.Equal(error, result.Error);
+        }
+
+        #endregion
+
+        #region Implicit Conversion Tests
+
+        [Fact]
+        public void ImplicitConversion_FromValue_CreatesSuccessResult()
+        {
+            // Act
+            Result<string, TestError> result = "test value";
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal("test value", result.Value);
+        }
+
+        #endregion
+
+        #region Value Access Tests
+
+        [Fact]
+        public void Value_OnSuccess_ReturnsValue()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act & Assert
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void Value_OnFailure_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Failure(new TestError("ERR", "Error"));
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => result.Value);
+            Assert.Contains("Cannot access Value", exception.Message);
+        }
+
+        [Fact]
+        public void Error_OnFailure_ReturnsError()
+        {
+            // Arrange
+            var error = new TestError("ERR001", "Test error");
+            var result = Result<int, TestError>.Failure(error);
+
+            // Act & Assert
+            Assert.Equal(error, result.Error);
+        }
+
+        [Fact]
+        public void Error_OnSuccess_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => result.Error);
+            Assert.Contains("Cannot access Error", exception.Message);
+        }
+
+        #endregion
+
+        #region TryGet Tests
+
+        [Fact]
+        public void TryGetValue_OnSuccess_ReturnsTrueAndValue()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act
+            var success = result.TryGetValue(out var value);
+
+            // Assert
+            Assert.True(success);
+            Assert.Equal(42, value);
+        }
+
+        [Fact]
+        public void TryGetValue_OnFailure_ReturnsFalse()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Failure(new TestError("ERR", "Error"));
+
+            // Act
+            var success = result.TryGetValue(out var value);
+
+            // Assert
+            Assert.False(success);
+            Assert.Equal(default, value);
+        }
+
+        [Fact]
+        public void TryGetError_OnFailure_ReturnsTrueAndError()
+        {
+            // Arrange
+            var error = new TestError("ERR001", "Test error");
+            var result = Result<int, TestError>.Failure(error);
+
+            // Act
+            var hasError = result.TryGetError(out var retrievedError);
+
+            // Assert
+            Assert.True(hasError);
+            Assert.Equal(error, retrievedError);
+        }
+
+        [Fact]
+        public void TryGetError_OnSuccess_ReturnsFalse()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act
+            var hasError = result.TryGetError(out var error);
+
+            // Assert
+            Assert.False(hasError);
+            Assert.Null(error);
+        }
+
+        #endregion
+
+        #region GetValueOrDefault Tests
+
+        [Fact]
+        public void GetValueOrDefault_OnSuccess_ReturnsValue()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act
+            var value = result.GetValueOrDefault(0);
+
+            // Assert
+            Assert.Equal(42, value);
+        }
+
+        [Fact]
+        public void GetValueOrDefault_OnFailure_ReturnsDefault()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Failure(new TestError("ERR", "Error"));
+
+            // Act
+            var value = result.GetValueOrDefault(99);
+
+            // Assert
+            Assert.Equal(99, value);
+        }
+
+        [Fact]
+        public void GetValueOrDefault_WithFactory_OnFailure_CallsFactory()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Failure(new TestError("ERR", "Error"));
+
+            // Act
+            var value = result.GetValueOrDefault(() => 99);
+
+            // Assert
+            Assert.Equal(99, value);
+        }
+
+        [Fact]
+        public void GetValueOrDefault_WithErrorHandler_OnFailure_PassesError()
+        {
+            // Arrange
+            var error = new TestError("ERR001", "Test error");
+            var result = Result<string, TestError>.Failure(error);
+            TestError? capturedError = null;
+
+            // Act
+            var value = result.GetValueOrDefault(e => { capturedError = e; return "default"; });
+
+            // Assert
+            Assert.Equal("default", value);
+            Assert.Equal(error, capturedError);
+        }
+
+        #endregion
+
+        #region Match Tests
+
+        [Fact]
+        public void Match_OnSuccess_ExecutesSuccessHandler()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act
+            var output = result.Match(
+                onSuccess: v => $"Success: {v}",
+                onFailure: e => $"Failure: {e.Code}");
+
+            // Assert
+            Assert.Equal("Success: 42", output);
+        }
+
+        [Fact]
+        public void Match_OnFailure_ExecutesFailureHandler()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Failure(new TestError("ERR001", "Error"));
+
+            // Act
+            var output = result.Match(
+                onSuccess: v => $"Success: {v}",
+                onFailure: e => $"Failure: {e.Code}");
+
+            // Assert
+            Assert.Equal("Failure: ERR001", output);
+        }
+
+        #endregion
+
+        #region Switch Tests
+
+        [Fact]
+        public void Switch_OnSuccess_ExecutesSuccessAction()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+            int? capturedValue = null;
+            TestError? capturedError = null;
+
+            // Act
+            result.Switch(
+                onSuccess: v => capturedValue = v,
+                onFailure: e => capturedError = e);
+
+            // Assert
+            Assert.Equal(42, capturedValue);
+            Assert.Null(capturedError);
+        }
+
+        [Fact]
+        public void Switch_OnFailure_ExecutesFailureAction()
+        {
+            // Arrange
+            var error = new TestError("ERR001", "Test error");
+            var result = Result<int, TestError>.Failure(error);
+            int? capturedValue = null;
+            TestError? capturedError = null;
+
+            // Act
+            result.Switch(
+                onSuccess: v => capturedValue = v,
+                onFailure: e => capturedError = e);
+
+            // Assert
+            Assert.Null(capturedValue);
+            Assert.Equal(error, capturedError);
+        }
+
+        #endregion
+
+        #region Map Tests
+
+        [Fact]
+        public void Map_OnSuccess_TransformsValue()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act
+            var mapped = result.Map(v => v.ToString());
+
+            // Assert
+            Assert.True(mapped.IsSuccess);
+            Assert.Equal("42", mapped.Value);
+        }
+
+        [Fact]
+        public void Map_OnFailure_PreservesError()
+        {
+            // Arrange
+            var error = new TestError("ERR001", "Test error");
+            var result = Result<int, TestError>.Failure(error);
+
+            // Act
+            var mapped = result.Map(v => v.ToString());
+
+            // Assert
+            Assert.True(mapped.IsFailure);
+            Assert.Equal(error, mapped.Error);
+        }
+
+        [Fact]
+        public void MapError_OnFailure_TransformsError()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Failure(new TestError("ERR001", "Original"));
+
+            // Act
+            var mapped = result.MapError(e => new TestError(e.Code, $"Mapped: {e.Description}"));
+
+            // Assert
+            Assert.True(mapped.IsFailure);
+            Assert.Equal("Mapped: Original", mapped.Error.Description);
+        }
+
+        [Fact]
+        public void MapError_CanChangeErrorType()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Failure(new TestError("ERR001", "Test"));
+
+            // Act
+            var mapped = result.MapError(e => e.Code); // Transform to string error
+
+            // Assert
+            Assert.True(mapped.IsFailure);
+            Assert.Equal("ERR001", mapped.Error);
+        }
+
+        [Fact]
+        public void MapError_OnSuccess_PreservesValue()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act
+            var mapped = result.MapError(e => new TestError("NEW", "Should not happen"));
+
+            // Assert
+            Assert.True(mapped.IsSuccess);
+            Assert.Equal(42, mapped.Value);
+        }
+
+        #endregion
+
+        #region Bind Tests
+
+        [Fact]
+        public void Bind_OnSuccess_ChainsOperation()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act
+            var bound = result.Bind(v => Result<string, TestError>.Success($"Value: {v}"));
+
+            // Assert
+            Assert.True(bound.IsSuccess);
+            Assert.Equal("Value: 42", bound.Value);
+        }
+
+        [Fact]
+        public void Bind_OnSuccess_CanReturnFailure()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+            var error = new TestError("VAL001", "Validation failed");
+
+            // Act
+            var bound = result.Bind(v => Result<string, TestError>.Failure(error));
+
+            // Assert
+            Assert.True(bound.IsFailure);
+            Assert.Equal(error, bound.Error);
+        }
+
+        [Fact]
+        public void Bind_OnFailure_SkipsOperation()
+        {
+            // Arrange
+            var error = new TestError("ERR001", "Original error");
+            var result = Result<int, TestError>.Failure(error);
+            var operationCalled = false;
+
+            // Act
+            var bound = result.Bind(v => { operationCalled = true; return Result<string, TestError>.Success("test"); });
+
+            // Assert
+            Assert.True(bound.IsFailure);
+            Assert.Equal(error, bound.Error);
+            Assert.False(operationCalled);
+        }
+
+        #endregion
+
+        #region Tap Tests
+
+        [Fact]
+        public void Tap_OnSuccess_ExecutesAction()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+            int? capturedValue = null;
+
+            // Act
+            var tapped = result.Tap(v => capturedValue = v);
+
+            // Assert
+            Assert.Equal(42, capturedValue);
+            Assert.Equal(result, tapped);
+        }
+
+        [Fact]
+        public void Tap_OnFailure_SkipsAction()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Failure(new TestError("ERR", "Error"));
+            var actionCalled = false;
+
+            // Act
+            var tapped = result.Tap(v => actionCalled = true);
+
+            // Assert
+            Assert.False(actionCalled);
+        }
+
+        [Fact]
+        public void TapError_OnFailure_ExecutesAction()
+        {
+            // Arrange
+            var error = new TestError("ERR001", "Test error");
+            var result = Result<int, TestError>.Failure(error);
+            TestError? capturedError = null;
+
+            // Act
+            var tapped = result.TapError(e => capturedError = e);
+
+            // Assert
+            Assert.Equal(error, capturedError);
+        }
+
+        [Fact]
+        public void TapError_OnSuccess_SkipsAction()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+            var actionCalled = false;
+
+            // Act
+            var tapped = result.TapError(e => actionCalled = true);
+
+            // Assert
+            Assert.False(actionCalled);
+        }
+
+        #endregion
+
+        #region Ensure Tests
+
+        [Fact]
+        public void Ensure_WhenPredicatePasses_ReturnsOriginalResult()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act
+            var ensured = result.Ensure(v => v > 0, new TestError("VAL001", "Must be positive"));
+
+            // Assert
+            Assert.True(ensured.IsSuccess);
+            Assert.Equal(42, ensured.Value);
+        }
+
+        [Fact]
+        public void Ensure_WhenPredicateFails_ReturnsFailure()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(-5);
+            var error = new TestError("VAL001", "Must be positive");
+
+            // Act
+            var ensured = result.Ensure(v => v > 0, error);
+
+            // Assert
+            Assert.True(ensured.IsFailure);
+            Assert.Equal(error, ensured.Error);
+        }
+
+        [Fact]
+        public void Ensure_OnFailure_SkipsPredicate()
+        {
+            // Arrange
+            var originalError = new TestError("ERR001", "Original error");
+            var result = Result<int, TestError>.Failure(originalError);
+            var predicateCalled = false;
+
+            // Act
+            var ensured = result.Ensure(v => { predicateCalled = true; return v > 0; }, new TestError("NEW", "New"));
+
+            // Assert
+            Assert.True(ensured.IsFailure);
+            Assert.Equal(originalError, ensured.Error);
+            Assert.False(predicateCalled);
+        }
+
+        #endregion
+
+        #region ToResult Tests
+
+        [Fact]
+        public void ToResult_OnSuccess_ConvertsToBuiltInResult()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act
+            var converted = result.ToResult(e => new ResultError(e.Description, e.Code));
+
+            // Assert
+            Assert.True(converted.IsSuccess);
+            Assert.Equal(42, converted.Value);
+        }
+
+        [Fact]
+        public void ToResult_OnFailure_ConvertsErrorToResultError()
+        {
+            // Arrange
+            var error = new TestError("ERR001", "Test error");
+            var result = Result<int, TestError>.Failure(error);
+
+            // Act
+            var converted = result.ToResult(e => new ResultError(e.Description, e.Code));
+
+            // Assert
+            Assert.True(converted.IsFailure);
+            Assert.Equal("Test error", converted.Error.Message);
+            Assert.Equal("ERR001", converted.Error.Code);
+        }
+
+        #endregion
+
+        #region Equality Tests
+
+        [Fact]
+        public void Equals_SuccessResultsWithSameValue_ReturnsTrue()
+        {
+            // Arrange
+            var result1 = Result<int, TestError>.Success(42);
+            var result2 = Result<int, TestError>.Success(42);
+
+            // Act & Assert
+            Assert.Equal(result1, result2);
+            Assert.True(result1 == result2);
+            Assert.False(result1 != result2);
+        }
+
+        [Fact]
+        public void Equals_SuccessResultsWithDifferentValues_ReturnsFalse()
+        {
+            // Arrange
+            var result1 = Result<int, TestError>.Success(42);
+            var result2 = Result<int, TestError>.Success(99);
+
+            // Act & Assert
+            Assert.NotEqual(result1, result2);
+        }
+
+        [Fact]
+        public void Equals_FailureResultsWithSameError_ReturnsTrue()
+        {
+            // Arrange
+            var error = new TestError("ERR001", "Test error");
+            var result1 = Result<int, TestError>.Failure(error);
+            var result2 = Result<int, TestError>.Failure(error);
+
+            // Act & Assert
+            Assert.Equal(result1, result2);
+        }
+
+        [Fact]
+        public void Equals_SuccessAndFailure_ReturnsFalse()
+        {
+            // Arrange
+            var success = Result<int, TestError>.Success(42);
+            var failure = Result<int, TestError>.Failure(new TestError("ERR", "Error"));
+
+            // Act & Assert
+            Assert.NotEqual(success, failure);
+        }
+
+        [Fact]
+        public void GetHashCode_SameResults_ReturnsSameHashCode()
+        {
+            // Arrange
+            var result1 = Result<int, TestError>.Success(42);
+            var result2 = Result<int, TestError>.Success(42);
+
+            // Act & Assert
+            Assert.Equal(result1.GetHashCode(), result2.GetHashCode());
+        }
+
+        #endregion
+
+        #region ToString Tests
+
+        [Fact]
+        public void ToString_OnSuccess_ReturnsFormattedString()
+        {
+            // Arrange
+            var result = Result<int, TestError>.Success(42);
+
+            // Act
+            var str = result.ToString();
+
+            // Assert
+            Assert.Equal("Success(42)", str);
+        }
+
+        [Fact]
+        public void ToString_OnFailure_ReturnsFormattedString()
+        {
+            // Arrange
+            var error = new TestError("ERR001", "Test error");
+            var result = Result<int, TestError>.Failure(error);
+
+            // Act
+            var str = result.ToString();
+
+            // Assert
+            Assert.Contains("Failure", str);
+        }
+
+        #endregion
+    }
+}

--- a/src/Cortex.Tests/Types/Tests/ResultErrorTests.cs
+++ b/src/Cortex.Tests/Types/Tests/ResultErrorTests.cs
@@ -1,0 +1,221 @@
+using Cortex.Types;
+
+namespace Cortex.Tests.Types.Tests
+{
+    public class ResultErrorTests
+    {
+        [Fact]
+        public void Constructor_WithMessage_SetsMessageProperty()
+        {
+            // Arrange & Act
+            var error = new ResultError("Test error");
+
+            // Assert
+            Assert.Equal("Test error", error.Message);
+            Assert.Null(error.Code);
+            Assert.Null(error.Exception);
+            Assert.Empty(error.Metadata);
+        }
+
+        [Fact]
+        public void Constructor_WithMessageAndCode_SetsBothProperties()
+        {
+            // Arrange & Act
+            var error = new ResultError("Test error", "ERR001");
+
+            // Assert
+            Assert.Equal("Test error", error.Message);
+            Assert.Equal("ERR001", error.Code);
+            Assert.Null(error.Exception);
+        }
+
+        [Fact]
+        public void Constructor_WithMessageAndException_SetsBothProperties()
+        {
+            // Arrange
+            var exception = new InvalidOperationException("Inner exception");
+
+            // Act
+            var error = new ResultError("Test error", exception);
+
+            // Assert
+            Assert.Equal("Test error", error.Message);
+            Assert.Null(error.Code);
+            Assert.Same(exception, error.Exception);
+        }
+
+        [Fact]
+        public void Constructor_WithAllParameters_SetsAllProperties()
+        {
+            // Arrange
+            var exception = new InvalidOperationException("Inner exception");
+            var metadata = new Dictionary<string, object> { ["key"] = "value" };
+
+            // Act
+            var error = new ResultError("Test error", "ERR001", exception, metadata);
+
+            // Assert
+            Assert.Equal("Test error", error.Message);
+            Assert.Equal("ERR001", error.Code);
+            Assert.Same(exception, error.Exception);
+            Assert.Equal("value", error.Metadata["key"]);
+        }
+
+        [Fact]
+        public void Constructor_WithNullMessage_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new ResultError(null!));
+        }
+
+        [Fact]
+        public void FromException_CreatesErrorFromException()
+        {
+            // Arrange
+            var exception = new ArgumentException("Argument error");
+
+            // Act
+            var error = ResultError.FromException(exception);
+
+            // Assert
+            Assert.Equal("Argument error", error.Message);
+            Assert.Equal("ArgumentException", error.Code);
+            Assert.Same(exception, error.Exception);
+        }
+
+        [Fact]
+        public void FromException_WithNullException_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => ResultError.FromException(null!));
+        }
+
+        [Fact]
+        public void Aggregate_WithSingleError_ReturnsSameError()
+        {
+            // Arrange
+            var error = new ResultError("Single error");
+
+            // Act
+            var result = ResultError.Aggregate(new[] { error });
+
+            // Assert
+            Assert.Same(error, result);
+        }
+
+        [Fact]
+        public void Aggregate_WithMultipleErrors_CreatesCompositeError()
+        {
+            // Arrange
+            var error1 = new ResultError("Error 1");
+            var error2 = new ResultError("Error 2");
+
+            // Act
+            var result = ResultError.Aggregate(new[] { error1, error2 });
+
+            // Assert
+            Assert.Contains("Error 1", result.Message);
+            Assert.Contains("Error 2", result.Message);
+            Assert.Equal("AGGREGATE_ERROR", result.Code);
+            Assert.True(result.Metadata.ContainsKey("InnerErrors"));
+        }
+
+        [Fact]
+        public void Aggregate_WithNullCollection_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => ResultError.Aggregate(null!));
+        }
+
+        [Fact]
+        public void Aggregate_WithEmptyCollection_ThrowsArgumentException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => ResultError.Aggregate(Array.Empty<ResultError>()));
+        }
+
+        [Fact]
+        public void Equals_WithSameMessageAndCode_ReturnsTrue()
+        {
+            // Arrange
+            var error1 = new ResultError("Test error", "ERR001");
+            var error2 = new ResultError("Test error", "ERR001");
+
+            // Act & Assert
+            Assert.Equal(error1, error2);
+            Assert.True(error1 == error2);
+            Assert.False(error1 != error2);
+        }
+
+        [Fact]
+        public void Equals_WithDifferentMessage_ReturnsFalse()
+        {
+            // Arrange
+            var error1 = new ResultError("Error 1");
+            var error2 = new ResultError("Error 2");
+
+            // Act & Assert
+            Assert.NotEqual(error1, error2);
+            Assert.False(error1 == error2);
+            Assert.True(error1 != error2);
+        }
+
+        [Fact]
+        public void Equals_WithDifferentCode_ReturnsFalse()
+        {
+            // Arrange
+            var error1 = new ResultError("Test error", "ERR001");
+            var error2 = new ResultError("Test error", "ERR002");
+
+            // Act & Assert
+            Assert.NotEqual(error1, error2);
+        }
+
+        [Fact]
+        public void Equals_WithNull_ReturnsFalse()
+        {
+            // Arrange
+            var error = new ResultError("Test error");
+
+            // Act & Assert
+            Assert.False(error.Equals(null));
+        }
+
+        [Fact]
+        public void GetHashCode_SameErrors_ReturnsSameHashCode()
+        {
+            // Arrange
+            var error1 = new ResultError("Test error", "ERR001");
+            var error2 = new ResultError("Test error", "ERR001");
+
+            // Act & Assert
+            Assert.Equal(error1.GetHashCode(), error2.GetHashCode());
+        }
+
+        [Fact]
+        public void ToString_WithoutCode_ReturnsMessage()
+        {
+            // Arrange
+            var error = new ResultError("Test error");
+
+            // Act
+            var result = error.ToString();
+
+            // Assert
+            Assert.Equal("Test error", result);
+        }
+
+        [Fact]
+        public void ToString_WithCode_ReturnsFormattedString()
+        {
+            // Arrange
+            var error = new ResultError("Test error", "ERR001");
+
+            // Act
+            var result = error.ToString();
+
+            // Assert
+            Assert.Equal("[ERR001] Test error", result);
+        }
+    }
+}

--- a/src/Cortex.Tests/Types/Tests/ResultExtensionsTests.cs
+++ b/src/Cortex.Tests/Types/Tests/ResultExtensionsTests.cs
@@ -1,0 +1,483 @@
+using Cortex.Types;
+
+namespace Cortex.Tests.Types.Tests
+{
+    public class ResultExtensionsTests
+    {
+        #region Static Factory Methods Tests
+
+        [Fact]
+        public void Success_CreatesSuccessfulResult()
+        {
+            // Act
+            var result = Result.Success(42);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void Success_WithCustomErrorType_CreatesSuccessfulResult()
+        {
+            // Act
+            var result = Result.Success<int, string>(42);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void Failure_WithError_CreatesFailedResult()
+        {
+            // Arrange
+            var error = new ResultError("Test error");
+
+            // Act
+            var result = Result.Failure<int>(error);
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal(error, result.Error);
+        }
+
+        [Fact]
+        public void Failure_WithMessage_CreatesFailedResult()
+        {
+            // Act
+            var result = Result.Failure<int>("Test error");
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal("Test error", result.Error.Message);
+        }
+
+        [Fact]
+        public void Failure_WithException_CreatesFailedResult()
+        {
+            // Arrange
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            var result = Result.Failure<int>(exception);
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal("Test exception", result.Error.Message);
+            Assert.Same(exception, result.Error.Exception);
+        }
+
+        [Fact]
+        public void Failure_WithCustomErrorType_CreatesFailedResult()
+        {
+            // Act
+            var result = Result.Failure<int, string>("Custom error");
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal("Custom error", result.Error);
+        }
+
+        #endregion
+
+        #region Try Tests
+
+        [Fact]
+        public void Try_WhenFunctionSucceeds_ReturnsSuccessResult()
+        {
+            // Act
+            var result = Result.Try(() => 42);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void Try_WhenFunctionThrows_ReturnsFailureResult()
+        {
+            // Arrange
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            var result = Result.Try<int>(() => throw exception);
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal("Test exception", result.Error.Message);
+            Assert.Same(exception, result.Error.Exception);
+        }
+
+        [Fact]
+        public void Try_WithExceptionHandler_WhenFunctionSucceeds_ReturnsSuccessResult()
+        {
+            // Act
+            var result = Result.Try(
+                () => 42,
+                ex => new ResultError($"Handled: {ex.Message}"));
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void Try_WithExceptionHandler_WhenFunctionThrows_UsesHandler()
+        {
+            // Arrange
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            var result = Result.Try<int>(
+                () => throw exception,
+                ex => new ResultError($"Handled: {ex.Message}", "HANDLED"));
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal("Handled: Test exception", result.Error.Message);
+            Assert.Equal("HANDLED", result.Error.Code);
+        }
+
+        #endregion
+
+        #region TryAsync Tests
+
+        [Fact]
+        public async Task TryAsync_WhenFunctionSucceeds_ReturnsSuccessResult()
+        {
+            // Act
+            var result = await Result.TryAsync(async () =>
+            {
+                await Task.Delay(1);
+                return 42;
+            });
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public async Task TryAsync_WhenFunctionThrows_ReturnsFailureResult()
+        {
+            // Arrange
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            var result = await Result.TryAsync<int>(async () =>
+            {
+                await Task.Delay(1);
+                throw exception;
+            });
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal("Test exception", result.Error.Message);
+            Assert.Same(exception, result.Error.Exception);
+        }
+
+        #endregion
+
+        #region Combine Tests
+
+        [Fact]
+        public void Combine_TwoSuccessResults_ReturnsCombinedSuccess()
+        {
+            // Arrange
+            var result1 = Result.Success(42);
+            var result2 = Result.Success("test");
+
+            // Act
+            var combined = Result.Combine(result1, result2);
+
+            // Assert
+            Assert.True(combined.IsSuccess);
+            Assert.Equal((42, "test"), combined.Value);
+        }
+
+        [Fact]
+        public void Combine_FirstResultFails_ReturnsFirstError()
+        {
+            // Arrange
+            var error = new ResultError("First error");
+            var result1 = Result.Failure<int>(error);
+            var result2 = Result.Success("test");
+
+            // Act
+            var combined = Result.Combine(result1, result2);
+
+            // Assert
+            Assert.True(combined.IsFailure);
+            Assert.Equal(error, combined.Error);
+        }
+
+        [Fact]
+        public void Combine_SecondResultFails_ReturnsSecondError()
+        {
+            // Arrange
+            var result1 = Result.Success(42);
+            var error = new ResultError("Second error");
+            var result2 = Result.Failure<string>(error);
+
+            // Act
+            var combined = Result.Combine(result1, result2);
+
+            // Assert
+            Assert.True(combined.IsFailure);
+            Assert.Equal(error, combined.Error);
+        }
+
+        [Fact]
+        public void Combine_BothResultsFail_ReturnsFirstError()
+        {
+            // Arrange
+            var error1 = new ResultError("First error");
+            var error2 = new ResultError("Second error");
+            var result1 = Result.Failure<int>(error1);
+            var result2 = Result.Failure<string>(error2);
+
+            // Act
+            var combined = Result.Combine(result1, result2);
+
+            // Assert
+            Assert.True(combined.IsFailure);
+            Assert.Equal(error1, combined.Error);
+        }
+
+        [Fact]
+        public void Combine_ThreeSuccessResults_ReturnsCombinedSuccess()
+        {
+            // Arrange
+            var result1 = Result.Success(42);
+            var result2 = Result.Success("test");
+            var result3 = Result.Success(3.14);
+
+            // Act
+            var combined = Result.Combine(result1, result2, result3);
+
+            // Assert
+            Assert.True(combined.IsSuccess);
+            Assert.Equal((42, "test", 3.14), combined.Value);
+        }
+
+        [Fact]
+        public void Combine_ThirdResultFails_ReturnsThirdError()
+        {
+            // Arrange
+            var result1 = Result.Success(42);
+            var result2 = Result.Success("test");
+            var error = new ResultError("Third error");
+            var result3 = Result.Failure<double>(error);
+
+            // Act
+            var combined = Result.Combine(result1, result2, result3);
+
+            // Assert
+            Assert.True(combined.IsFailure);
+            Assert.Equal(error, combined.Error);
+        }
+
+        #endregion
+
+        #region SuccessIf Tests
+
+        [Fact]
+        public void SuccessIf_WhenConditionIsTrue_ReturnsSuccess()
+        {
+            // Act
+            var result = Result.SuccessIf(true, 42, "Should not see this");
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void SuccessIf_WhenConditionIsFalse_ReturnsFailure()
+        {
+            // Act
+            var result = Result.SuccessIf(false, 42, "Condition failed");
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal("Condition failed", result.Error.Message);
+        }
+
+        [Fact]
+        public void SuccessIf_WithError_WhenConditionIsTrue_ReturnsSuccess()
+        {
+            // Arrange
+            var error = new ResultError("Should not see this");
+
+            // Act
+            var result = Result.SuccessIf(true, 42, error);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void SuccessIf_WithError_WhenConditionIsFalse_ReturnsFailure()
+        {
+            // Arrange
+            var error = new ResultError("Condition failed", "COND_FAIL");
+
+            // Act
+            var result = Result.SuccessIf(false, 42, error);
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal(error, result.Error);
+        }
+
+        #endregion
+
+        #region FailureIf Tests
+
+        [Fact]
+        public void FailureIf_WhenConditionIsTrue_ReturnsFailure()
+        {
+            // Act
+            var result = Result.FailureIf(true, 42, "Condition triggered failure");
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal("Condition triggered failure", result.Error.Message);
+        }
+
+        [Fact]
+        public void FailureIf_WhenConditionIsFalse_ReturnsSuccess()
+        {
+            // Act
+            var result = Result.FailureIf(false, 42, "Should not see this");
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void FailureIf_WithError_WhenConditionIsTrue_ReturnsFailure()
+        {
+            // Arrange
+            var error = new ResultError("Condition triggered failure", "COND_FAIL");
+
+            // Act
+            var result = Result.FailureIf(true, 42, error);
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal(error, result.Error);
+        }
+
+        [Fact]
+        public void FailureIf_WithError_WhenConditionIsFalse_ReturnsSuccess()
+        {
+            // Arrange
+            var error = new ResultError("Should not see this");
+
+            // Act
+            var result = Result.FailureIf(false, 42, error);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(42, result.Value);
+        }
+
+        #endregion
+
+        #region Real-World Scenario Tests
+
+        [Fact]
+        public void RealWorldScenario_ValidationChain()
+        {
+            // Arrange
+            string? username = "john_doe";
+
+            // Act
+            var result = Result.Success(username)
+                .Ensure(u => !string.IsNullOrEmpty(u), "Username cannot be empty")
+                .Ensure(u => u!.Length >= 3, "Username must be at least 3 characters")
+                .Ensure(u => u!.Length <= 20, "Username must be at most 20 characters")
+                .Map(u => u!.ToUpperInvariant());
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal("JOHN_DOE", result.Value);
+        }
+
+        [Fact]
+        public void RealWorldScenario_ValidationChainFails()
+        {
+            // Arrange
+            string? username = "ab";
+
+            // Act
+            var result = Result.Success(username)
+                .Ensure(u => !string.IsNullOrEmpty(u), "Username cannot be empty")
+                .Ensure(u => u!.Length >= 3, "Username must be at least 3 characters")
+                .Ensure(u => u!.Length <= 20, "Username must be at most 20 characters")
+                .Map(u => u!.ToUpperInvariant());
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal("Username must be at least 3 characters", result.Error.Message);
+        }
+
+        [Fact]
+        public void RealWorldScenario_ChainedOperations()
+        {
+            // Arrange
+            int ParseNumber(string s) => int.Parse(s);
+            int Double(int n) => n * 2;
+
+            // Act
+            var result = Result.Try(() => ParseNumber("21"))
+                .Map(Double)
+                .Map(n => $"Result: {n}");
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal("Result: 42", result.Value);
+        }
+
+        [Fact]
+        public void RealWorldScenario_ChainedOperationsWithFailure()
+        {
+            // Arrange
+            int ParseNumber(string s) => int.Parse(s);
+            int Double(int n) => n * 2;
+
+            // Act
+            var result = Result.Try(() => ParseNumber("not a number"))
+                .Map(Double)
+                .Map(n => $"Result: {n}");
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.NotNull(result.Error.Exception);
+        }
+
+        [Fact]
+        public async Task RealWorldScenario_AsyncOperations()
+        {
+            // Arrange
+            async Task<int> FetchDataAsync()
+            {
+                await Task.Delay(1);
+                return 42;
+            }
+
+            // Act
+            var result = await Result.TryAsync(FetchDataAsync);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(42, result.Value);
+        }
+
+        #endregion
+    }
+}

--- a/src/Cortex.Tests/Types/Tests/ResultTests.cs
+++ b/src/Cortex.Tests/Types/Tests/ResultTests.cs
@@ -1,0 +1,672 @@
+using Cortex.Types;
+
+namespace Cortex.Tests.Types.Tests
+{
+    public class ResultTests
+    {
+        #region Creation Tests
+
+        [Fact]
+        public void Success_CreatesSuccessfulResult()
+        {
+            // Act
+            var result = Result<int>.Success(42);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.False(result.IsFailure);
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void Failure_WithError_CreatesFailedResult()
+        {
+            // Arrange
+            var error = new ResultError("Test error");
+
+            // Act
+            var result = Result<int>.Failure(error);
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.True(result.IsFailure);
+            Assert.Equal(error, result.Error);
+        }
+
+        [Fact]
+        public void Failure_WithMessage_CreatesFailedResult()
+        {
+            // Act
+            var result = Result<int>.Failure("Test error");
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal("Test error", result.Error.Message);
+        }
+
+        [Fact]
+        public void Failure_WithException_CreatesFailedResult()
+        {
+            // Arrange
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            var result = Result<int>.Failure(exception);
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal("Test exception", result.Error.Message);
+            Assert.Same(exception, result.Error.Exception);
+        }
+
+        [Fact]
+        public void Failure_WithNullError_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => Result<int>.Failure((ResultError)null!));
+        }
+
+        #endregion
+
+        #region Implicit Conversion Tests
+
+        [Fact]
+        public void ImplicitConversion_FromValue_CreatesSuccessResult()
+        {
+            // Act
+            Result<string> result = "test value";
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal("test value", result.Value);
+        }
+
+        [Fact]
+        public void ImplicitConversion_FromError_CreatesFailedResult()
+        {
+            // Arrange
+            var error = new ResultError("Test error");
+
+            // Act
+            Result<int> result = error;
+
+            // Assert
+            Assert.True(result.IsFailure);
+            Assert.Equal(error, result.Error);
+        }
+
+        #endregion
+
+        #region Value Access Tests
+
+        [Fact]
+        public void Value_OnSuccess_ReturnsValue()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act & Assert
+            Assert.Equal(42, result.Value);
+        }
+
+        [Fact]
+        public void Value_OnFailure_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var result = Result<int>.Failure("Test error");
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => result.Value);
+            Assert.Contains("Cannot access Value", exception.Message);
+        }
+
+        [Fact]
+        public void Error_OnFailure_ReturnsError()
+        {
+            // Arrange
+            var error = new ResultError("Test error");
+            var result = Result<int>.Failure(error);
+
+            // Act & Assert
+            Assert.Equal(error, result.Error);
+        }
+
+        [Fact]
+        public void Error_OnSuccess_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => result.Error);
+            Assert.Contains("Cannot access Error", exception.Message);
+        }
+
+        #endregion
+
+        #region TryGet Tests
+
+        [Fact]
+        public void TryGetValue_OnSuccess_ReturnsTrueAndValue()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act
+            var success = result.TryGetValue(out var value);
+
+            // Assert
+            Assert.True(success);
+            Assert.Equal(42, value);
+        }
+
+        [Fact]
+        public void TryGetValue_OnFailure_ReturnsFalse()
+        {
+            // Arrange
+            var result = Result<int>.Failure("Test error");
+
+            // Act
+            var success = result.TryGetValue(out var value);
+
+            // Assert
+            Assert.False(success);
+            Assert.Equal(default, value);
+        }
+
+        [Fact]
+        public void TryGetError_OnFailure_ReturnsTrueAndError()
+        {
+            // Arrange
+            var error = new ResultError("Test error");
+            var result = Result<int>.Failure(error);
+
+            // Act
+            var hasError = result.TryGetError(out var retrievedError);
+
+            // Assert
+            Assert.True(hasError);
+            Assert.Equal(error, retrievedError);
+        }
+
+        [Fact]
+        public void TryGetError_OnSuccess_ReturnsFalse()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act
+            var hasError = result.TryGetError(out var error);
+
+            // Assert
+            Assert.False(hasError);
+            Assert.Null(error);
+        }
+
+        #endregion
+
+        #region GetValueOrDefault Tests
+
+        [Fact]
+        public void GetValueOrDefault_OnSuccess_ReturnsValue()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act
+            var value = result.GetValueOrDefault(0);
+
+            // Assert
+            Assert.Equal(42, value);
+        }
+
+        [Fact]
+        public void GetValueOrDefault_OnFailure_ReturnsDefault()
+        {
+            // Arrange
+            var result = Result<int>.Failure("Test error");
+
+            // Act
+            var value = result.GetValueOrDefault(99);
+
+            // Assert
+            Assert.Equal(99, value);
+        }
+
+        [Fact]
+        public void GetValueOrDefault_WithFactory_OnSuccess_ReturnsValue()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+            var factoryCalled = false;
+
+            // Act
+            var value = result.GetValueOrDefault(() => { factoryCalled = true; return 99; });
+
+            // Assert
+            Assert.Equal(42, value);
+            Assert.False(factoryCalled);
+        }
+
+        [Fact]
+        public void GetValueOrDefault_WithFactory_OnFailure_CallsFactory()
+        {
+            // Arrange
+            var result = Result<int>.Failure("Test error");
+
+            // Act
+            var value = result.GetValueOrDefault(() => 99);
+
+            // Assert
+            Assert.Equal(99, value);
+        }
+
+        [Fact]
+        public void GetValueOrDefault_WithErrorHandler_OnFailure_PassesError()
+        {
+            // Arrange
+            var error = new ResultError("Test error");
+            var result = Result<string>.Failure(error);
+            ResultError? capturedError = null;
+
+            // Act
+            var value = result.GetValueOrDefault(e => { capturedError = e; return "default"; });
+
+            // Assert
+            Assert.Equal("default", value);
+            Assert.Equal(error, capturedError);
+        }
+
+        #endregion
+
+        #region Match Tests
+
+        [Fact]
+        public void Match_OnSuccess_ExecutesSuccessHandler()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act
+            var output = result.Match(
+                onSuccess: v => $"Success: {v}",
+                onFailure: e => $"Failure: {e.Message}");
+
+            // Assert
+            Assert.Equal("Success: 42", output);
+        }
+
+        [Fact]
+        public void Match_OnFailure_ExecutesFailureHandler()
+        {
+            // Arrange
+            var result = Result<int>.Failure("Test error");
+
+            // Act
+            var output = result.Match(
+                onSuccess: v => $"Success: {v}",
+                onFailure: e => $"Failure: {e.Message}");
+
+            // Assert
+            Assert.Equal("Failure: Test error", output);
+        }
+
+        #endregion
+
+        #region Switch Tests
+
+        [Fact]
+        public void Switch_OnSuccess_ExecutesSuccessAction()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+            int? capturedValue = null;
+            ResultError? capturedError = null;
+
+            // Act
+            result.Switch(
+                onSuccess: v => capturedValue = v,
+                onFailure: e => capturedError = e);
+
+            // Assert
+            Assert.Equal(42, capturedValue);
+            Assert.Null(capturedError);
+        }
+
+        [Fact]
+        public void Switch_OnFailure_ExecutesFailureAction()
+        {
+            // Arrange
+            var error = new ResultError("Test error");
+            var result = Result<int>.Failure(error);
+            int? capturedValue = null;
+            ResultError? capturedError = null;
+
+            // Act
+            result.Switch(
+                onSuccess: v => capturedValue = v,
+                onFailure: e => capturedError = e);
+
+            // Assert
+            Assert.Null(capturedValue);
+            Assert.Equal(error, capturedError);
+        }
+
+        #endregion
+
+        #region Map Tests
+
+        [Fact]
+        public void Map_OnSuccess_TransformsValue()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act
+            var mapped = result.Map(v => v.ToString());
+
+            // Assert
+            Assert.True(mapped.IsSuccess);
+            Assert.Equal("42", mapped.Value);
+        }
+
+        [Fact]
+        public void Map_OnFailure_PreservesError()
+        {
+            // Arrange
+            var error = new ResultError("Test error");
+            var result = Result<int>.Failure(error);
+
+            // Act
+            var mapped = result.Map(v => v.ToString());
+
+            // Assert
+            Assert.True(mapped.IsFailure);
+            Assert.Equal(error, mapped.Error);
+        }
+
+        [Fact]
+        public void MapError_OnFailure_TransformsError()
+        {
+            // Arrange
+            var result = Result<int>.Failure("Original error");
+
+            // Act
+            var mapped = result.MapError(e => new ResultError($"Mapped: {e.Message}"));
+
+            // Assert
+            Assert.True(mapped.IsFailure);
+            Assert.Equal("Mapped: Original error", mapped.Error.Message);
+        }
+
+        [Fact]
+        public void MapError_OnSuccess_PreservesValue()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act
+            var mapped = result.MapError(e => new ResultError("Should not happen"));
+
+            // Assert
+            Assert.True(mapped.IsSuccess);
+            Assert.Equal(42, mapped.Value);
+        }
+
+        #endregion
+
+        #region Bind Tests
+
+        [Fact]
+        public void Bind_OnSuccess_ChainsOperation()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act
+            var bound = result.Bind(v => Result<string>.Success($"Value: {v}"));
+
+            // Assert
+            Assert.True(bound.IsSuccess);
+            Assert.Equal("Value: 42", bound.Value);
+        }
+
+        [Fact]
+        public void Bind_OnSuccess_CanReturnFailure()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act
+            var bound = result.Bind(v => Result<string>.Failure("Validation failed"));
+
+            // Assert
+            Assert.True(bound.IsFailure);
+            Assert.Equal("Validation failed", bound.Error.Message);
+        }
+
+        [Fact]
+        public void Bind_OnFailure_SkipsOperation()
+        {
+            // Arrange
+            var error = new ResultError("Original error");
+            var result = Result<int>.Failure(error);
+            var operationCalled = false;
+
+            // Act
+            var bound = result.Bind(v => { operationCalled = true; return Result<string>.Success("test"); });
+
+            // Assert
+            Assert.True(bound.IsFailure);
+            Assert.Equal(error, bound.Error);
+            Assert.False(operationCalled);
+        }
+
+        #endregion
+
+        #region Tap Tests
+
+        [Fact]
+        public void Tap_OnSuccess_ExecutesAction()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+            int? capturedValue = null;
+
+            // Act
+            var tapped = result.Tap(v => capturedValue = v);
+
+            // Assert
+            Assert.Equal(42, capturedValue);
+            Assert.Equal(result, tapped);
+        }
+
+        [Fact]
+        public void Tap_OnFailure_SkipsAction()
+        {
+            // Arrange
+            var result = Result<int>.Failure("Test error");
+            var actionCalled = false;
+
+            // Act
+            var tapped = result.Tap(v => actionCalled = true);
+
+            // Assert
+            Assert.False(actionCalled);
+            Assert.Equal(result, tapped);
+        }
+
+        [Fact]
+        public void TapError_OnFailure_ExecutesAction()
+        {
+            // Arrange
+            var error = new ResultError("Test error");
+            var result = Result<int>.Failure(error);
+            ResultError? capturedError = null;
+
+            // Act
+            var tapped = result.TapError(e => capturedError = e);
+
+            // Assert
+            Assert.Equal(error, capturedError);
+            Assert.Equal(result, tapped);
+        }
+
+        [Fact]
+        public void TapError_OnSuccess_SkipsAction()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+            var actionCalled = false;
+
+            // Act
+            var tapped = result.TapError(e => actionCalled = true);
+
+            // Assert
+            Assert.False(actionCalled);
+            Assert.Equal(result, tapped);
+        }
+
+        #endregion
+
+        #region Ensure Tests
+
+        [Fact]
+        public void Ensure_WhenPredicatePasses_ReturnsOriginalResult()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act
+            var ensured = result.Ensure(v => v > 0, "Value must be positive");
+
+            // Assert
+            Assert.True(ensured.IsSuccess);
+            Assert.Equal(42, ensured.Value);
+        }
+
+        [Fact]
+        public void Ensure_WhenPredicateFails_ReturnsFailure()
+        {
+            // Arrange
+            var result = Result<int>.Success(-5);
+
+            // Act
+            var ensured = result.Ensure(v => v > 0, "Value must be positive");
+
+            // Assert
+            Assert.True(ensured.IsFailure);
+            Assert.Equal("Value must be positive", ensured.Error.Message);
+        }
+
+        [Fact]
+        public void Ensure_OnFailure_SkipsPredicate()
+        {
+            // Arrange
+            var result = Result<int>.Failure("Original error");
+            var predicateCalled = false;
+
+            // Act
+            var ensured = result.Ensure(v => { predicateCalled = true; return v > 0; }, "Should not see this");
+
+            // Assert
+            Assert.True(ensured.IsFailure);
+            Assert.Equal("Original error", ensured.Error.Message);
+            Assert.False(predicateCalled);
+        }
+
+        #endregion
+
+        #region Equality Tests
+
+        [Fact]
+        public void Equals_SuccessResultsWithSameValue_ReturnsTrue()
+        {
+            // Arrange
+            var result1 = Result<int>.Success(42);
+            var result2 = Result<int>.Success(42);
+
+            // Act & Assert
+            Assert.Equal(result1, result2);
+            Assert.True(result1 == result2);
+            Assert.False(result1 != result2);
+        }
+
+        [Fact]
+        public void Equals_SuccessResultsWithDifferentValues_ReturnsFalse()
+        {
+            // Arrange
+            var result1 = Result<int>.Success(42);
+            var result2 = Result<int>.Success(99);
+
+            // Act & Assert
+            Assert.NotEqual(result1, result2);
+        }
+
+        [Fact]
+        public void Equals_FailureResultsWithSameError_ReturnsTrue()
+        {
+            // Arrange
+            var result1 = Result<int>.Failure("Test error");
+            var result2 = Result<int>.Failure("Test error");
+
+            // Act & Assert
+            Assert.Equal(result1, result2);
+        }
+
+        [Fact]
+        public void Equals_SuccessAndFailure_ReturnsFalse()
+        {
+            // Arrange
+            var success = Result<int>.Success(42);
+            var failure = Result<int>.Failure("Test error");
+
+            // Act & Assert
+            Assert.NotEqual(success, failure);
+        }
+
+        [Fact]
+        public void GetHashCode_SameResults_ReturnsSameHashCode()
+        {
+            // Arrange
+            var result1 = Result<int>.Success(42);
+            var result2 = Result<int>.Success(42);
+
+            // Act & Assert
+            Assert.Equal(result1.GetHashCode(), result2.GetHashCode());
+        }
+
+        #endregion
+
+        #region ToString Tests
+
+        [Fact]
+        public void ToString_OnSuccess_ReturnsFormattedString()
+        {
+            // Arrange
+            var result = Result<int>.Success(42);
+
+            // Act
+            var str = result.ToString();
+
+            // Assert
+            Assert.Equal("Success(42)", str);
+        }
+
+        [Fact]
+        public void ToString_OnFailure_ReturnsFormattedString()
+        {
+            // Arrange
+            var result = Result<int>.Failure("Test error");
+
+            // Act
+            var str = result.ToString();
+
+            // Assert
+            Assert.Contains("Failure", str);
+            Assert.Contains("Test error", str);
+        }
+
+        #endregion
+    }
+}

--- a/src/Cortex.Types/AnyOf/AnyOf5.cs
+++ b/src/Cortex.Types/AnyOf/AnyOf5.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Cortex.Types
+{
+    /// <summary>
+    /// Represents a value that can be any of five specified types
+    /// </summary>
+    /// <typeparam name="T1">First possible type</typeparam>
+    /// <typeparam name="T2">Second possible type</typeparam>
+    /// <typeparam name="T3">Third possible type</typeparam>
+    /// <typeparam name="T4">Fourth possible type</typeparam>
+    /// <typeparam name="T5">Fifth possible type</typeparam>
+    public readonly struct AnyOf<T1, T2, T3, T4, T5> : IEquatable<AnyOf<T1, T2, T3, T4, T5>>, IAnyOf
+    {
+        private readonly object _value;
+        private readonly HashSet<int> _typeIndices;
+
+        /// <inheritdoc />
+        public object Value => _value;
+
+        /// <inheritdoc />
+        public IEnumerable<int> TypeIndices => _typeIndices;
+
+        private AnyOf(object value, HashSet<int> typeIndices) =>
+            (_value, _typeIndices) = (value, typeIndices);
+
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5>(T1 value) => new(value, new HashSet<int> { 0 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5>(T2 value) => new(value, new HashSet<int> { 1 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5>(T3 value) => new(value, new HashSet<int> { 2 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5>(T4 value) => new(value, new HashSet<int> { 3 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5>(T5 value) => new(value, new HashSet<int> { 4 });
+
+        /// <summary>
+        /// Checks if the contained value is of or derived from type <typeparamref name="T"/>
+        /// </summary>
+        public bool Is<T>() => _value is T;
+
+        /// <summary>
+        /// Returns the contained value as <typeparamref name="T"/>
+        /// </summary>
+        /// <exception cref="InvalidCastException">
+        /// Thrown when value is not compatible with <typeparamref name="T"/>
+        /// </exception>
+        public T As<T>() => _value is T val
+            ? val
+            : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
+
+        /// <summary>
+        /// Attempts to retrieve the value as <typeparamref name="T"/>
+        /// </summary>
+        public bool TryGet<T>([NotNullWhen(true)] out T result)
+        {
+            if (_value is T val)
+            {
+                result = val;
+                return true;
+            }
+
+            result = default!;
+            return false;
+        }
+
+        /// <summary>
+        /// Type-safe pattern matching with exhaustive case handling
+        /// </summary>
+        public TResult Match<TResult>(
+            Func<T1, TResult> t1Handler,
+            Func<T2, TResult> t2Handler,
+            Func<T3, TResult> t3Handler,
+            Func<T4, TResult> t4Handler,
+            Func<T5, TResult> t5Handler)
+        {
+            if (_typeIndices.Contains(0) && _value is T1 t1) return t1Handler(t1);
+            if (_typeIndices.Contains(1) && _value is T2 t2) return t2Handler(t2);
+            if (_typeIndices.Contains(2) && _value is T3 t3) return t3Handler(t3);
+            if (_typeIndices.Contains(3) && _value is T4 t4) return t4Handler(t4);
+            if (_typeIndices.Contains(4) && _value is T5 t5) return t5Handler(t5);
+            throw new InvalidOperationException("Invalid state");
+        }
+
+        /// <summary>
+        /// Executes type-specific action with exhaustive case handling
+        /// </summary>
+        public void Switch(
+            Action<T1> t1Action,
+            Action<T2> t2Action,
+            Action<T3> t3Action,
+            Action<T4> t4Action,
+            Action<T5> t5Action)
+        {
+            if (_typeIndices.Contains(0) && _value is T1 t1) { t1Action(t1); return; }
+            if (_typeIndices.Contains(1) && _value is T2 t2) { t2Action(t2); return; }
+            if (_typeIndices.Contains(2) && _value is T3 t3) { t3Action(t3); return; }
+            if (_typeIndices.Contains(3) && _value is T4 t4) { t4Action(t4); return; }
+            if (_typeIndices.Contains(4) && _value is T5 t5) { t5Action(t5); return; }
+            throw new InvalidOperationException("Invalid state");
+        }
+
+        /// <summary>
+        /// Returns all of the type parameters for which the stored value is assignable.
+        /// </summary>
+        public IEnumerable<Type> GetMatchingTypes()
+        {
+            if (_value is T1) yield return typeof(T1);
+            if (_value is T2) yield return typeof(T2);
+            if (_value is T3) yield return typeof(T3);
+            if (_value is T4) yield return typeof(T4);
+            if (_value is T5) yield return typeof(T5);
+        }
+
+        private string GetCastErrorMessage(Type targetType) =>
+            $"Cannot cast stored type {_value?.GetType().Name ?? "null"} to {targetType.Name}";
+
+        public bool Equals(AnyOf<T1, T2, T3, T4, T5> other) =>
+            _typeIndices.SetEquals(other._typeIndices) &&
+            Equals(_value, other._value);
+
+        public override bool Equals(object obj) =>
+            obj is AnyOf<T1, T2, T3, T4, T5> other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(_value, _typeIndices);
+
+        public static bool operator ==(AnyOf<T1, T2, T3, T4, T5> left, AnyOf<T1, T2, T3, T4, T5> right) =>
+            left.Equals(right);
+
+        public static bool operator !=(AnyOf<T1, T2, T3, T4, T5> left, AnyOf<T1, T2, T3, T4, T5> right) =>
+            !left.Equals(right);
+
+        public override string ToString() =>
+            _value?.ToString() ?? string.Empty;
+    }
+}

--- a/src/Cortex.Types/AnyOf/AnyOf6.cs
+++ b/src/Cortex.Types/AnyOf/AnyOf6.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Cortex.Types
+{
+    /// <summary>
+    /// Represents a value that can be any of six specified types
+    /// </summary>
+    /// <typeparam name="T1">First possible type</typeparam>
+    /// <typeparam name="T2">Second possible type</typeparam>
+    /// <typeparam name="T3">Third possible type</typeparam>
+    /// <typeparam name="T4">Fourth possible type</typeparam>
+    /// <typeparam name="T5">Fifth possible type</typeparam>
+    /// <typeparam name="T6">Sixth possible type</typeparam>
+    public readonly struct AnyOf<T1, T2, T3, T4, T5, T6> : IEquatable<AnyOf<T1, T2, T3, T4, T5, T6>>, IAnyOf
+    {
+        private readonly object _value;
+        private readonly HashSet<int> _typeIndices;
+
+        /// <inheritdoc />
+        public object Value => _value;
+
+        /// <inheritdoc />
+        public IEnumerable<int> TypeIndices => _typeIndices;
+
+        private AnyOf(object value, HashSet<int> typeIndices) =>
+            (_value, _typeIndices) = (value, typeIndices);
+
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6>(T1 value) => new(value, new HashSet<int> { 0 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6>(T2 value) => new(value, new HashSet<int> { 1 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6>(T3 value) => new(value, new HashSet<int> { 2 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6>(T4 value) => new(value, new HashSet<int> { 3 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6>(T5 value) => new(value, new HashSet<int> { 4 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6>(T6 value) => new(value, new HashSet<int> { 5 });
+
+        /// <summary>
+        /// Checks if the contained value is of or derived from type <typeparamref name="T"/>
+        /// </summary>
+        public bool Is<T>() => _value is T;
+
+        /// <summary>
+        /// Returns the contained value as <typeparamref name="T"/>
+        /// </summary>
+        /// <exception cref="InvalidCastException">
+        /// Thrown when value is not compatible with <typeparamref name="T"/>
+        /// </exception>
+        public T As<T>() => _value is T val
+            ? val
+            : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
+
+        /// <summary>
+        /// Attempts to retrieve the value as <typeparamref name="T"/>
+        /// </summary>
+        public bool TryGet<T>([NotNullWhen(true)] out T result)
+        {
+            if (_value is T val)
+            {
+                result = val;
+                return true;
+            }
+
+            result = default!;
+            return false;
+        }
+
+        /// <summary>
+        /// Type-safe pattern matching with exhaustive case handling
+        /// </summary>
+        public TResult Match<TResult>(
+            Func<T1, TResult> t1Handler,
+            Func<T2, TResult> t2Handler,
+            Func<T3, TResult> t3Handler,
+            Func<T4, TResult> t4Handler,
+            Func<T5, TResult> t5Handler,
+            Func<T6, TResult> t6Handler)
+        {
+            if (_typeIndices.Contains(0) && _value is T1 t1) return t1Handler(t1);
+            if (_typeIndices.Contains(1) && _value is T2 t2) return t2Handler(t2);
+            if (_typeIndices.Contains(2) && _value is T3 t3) return t3Handler(t3);
+            if (_typeIndices.Contains(3) && _value is T4 t4) return t4Handler(t4);
+            if (_typeIndices.Contains(4) && _value is T5 t5) return t5Handler(t5);
+            if (_typeIndices.Contains(5) && _value is T6 t6) return t6Handler(t6);
+            throw new InvalidOperationException("Invalid state");
+        }
+
+        /// <summary>
+        /// Executes type-specific action with exhaustive case handling
+        /// </summary>
+        public void Switch(
+            Action<T1> t1Action,
+            Action<T2> t2Action,
+            Action<T3> t3Action,
+            Action<T4> t4Action,
+            Action<T5> t5Action,
+            Action<T6> t6Action)
+        {
+            if (_typeIndices.Contains(0) && _value is T1 t1) { t1Action(t1); return; }
+            if (_typeIndices.Contains(1) && _value is T2 t2) { t2Action(t2); return; }
+            if (_typeIndices.Contains(2) && _value is T3 t3) { t3Action(t3); return; }
+            if (_typeIndices.Contains(3) && _value is T4 t4) { t4Action(t4); return; }
+            if (_typeIndices.Contains(4) && _value is T5 t5) { t5Action(t5); return; }
+            if (_typeIndices.Contains(5) && _value is T6 t6) { t6Action(t6); return; }
+            throw new InvalidOperationException("Invalid state");
+        }
+
+        /// <summary>
+        /// Returns all of the type parameters for which the stored value is assignable.
+        /// </summary>
+        public IEnumerable<Type> GetMatchingTypes()
+        {
+            if (_value is T1) yield return typeof(T1);
+            if (_value is T2) yield return typeof(T2);
+            if (_value is T3) yield return typeof(T3);
+            if (_value is T4) yield return typeof(T4);
+            if (_value is T5) yield return typeof(T5);
+            if (_value is T6) yield return typeof(T6);
+        }
+
+        private string GetCastErrorMessage(Type targetType) =>
+            $"Cannot cast stored type {_value?.GetType().Name ?? "null"} to {targetType.Name}";
+
+        public bool Equals(AnyOf<T1, T2, T3, T4, T5, T6> other) =>
+            _typeIndices.SetEquals(other._typeIndices) &&
+            Equals(_value, other._value);
+
+        public override bool Equals(object obj) =>
+            obj is AnyOf<T1, T2, T3, T4, T5, T6> other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(_value, _typeIndices);
+
+        public static bool operator ==(AnyOf<T1, T2, T3, T4, T5, T6> left, AnyOf<T1, T2, T3, T4, T5, T6> right) =>
+            left.Equals(right);
+
+        public static bool operator !=(AnyOf<T1, T2, T3, T4, T5, T6> left, AnyOf<T1, T2, T3, T4, T5, T6> right) =>
+            !left.Equals(right);
+
+        public override string ToString() =>
+            _value?.ToString() ?? string.Empty;
+    }
+}

--- a/src/Cortex.Types/AnyOf/AnyOf7.cs
+++ b/src/Cortex.Types/AnyOf/AnyOf7.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Cortex.Types
+{
+    /// <summary>
+    /// Represents a value that can be any of seven specified types
+    /// </summary>
+    /// <typeparam name="T1">First possible type</typeparam>
+    /// <typeparam name="T2">Second possible type</typeparam>
+    /// <typeparam name="T3">Third possible type</typeparam>
+    /// <typeparam name="T4">Fourth possible type</typeparam>
+    /// <typeparam name="T5">Fifth possible type</typeparam>
+    /// <typeparam name="T6">Sixth possible type</typeparam>
+    /// <typeparam name="T7">Seventh possible type</typeparam>
+    public readonly struct AnyOf<T1, T2, T3, T4, T5, T6, T7> : IEquatable<AnyOf<T1, T2, T3, T4, T5, T6, T7>>, IAnyOf
+    {
+        private readonly object _value;
+        private readonly HashSet<int> _typeIndices;
+
+        /// <inheritdoc />
+        public object Value => _value;
+
+        /// <inheritdoc />
+        public IEnumerable<int> TypeIndices => _typeIndices;
+
+        private AnyOf(object value, HashSet<int> typeIndices) =>
+            (_value, _typeIndices) = (value, typeIndices);
+
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7>(T1 value) => new(value, new HashSet<int> { 0 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7>(T2 value) => new(value, new HashSet<int> { 1 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7>(T3 value) => new(value, new HashSet<int> { 2 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7>(T4 value) => new(value, new HashSet<int> { 3 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7>(T5 value) => new(value, new HashSet<int> { 4 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7>(T6 value) => new(value, new HashSet<int> { 5 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7>(T7 value) => new(value, new HashSet<int> { 6 });
+
+        /// <summary>
+        /// Checks if the contained value is of or derived from type <typeparamref name="T"/>
+        /// </summary>
+        public bool Is<T>() => _value is T;
+
+        /// <summary>
+        /// Returns the contained value as <typeparamref name="T"/>
+        /// </summary>
+        /// <exception cref="InvalidCastException">
+        /// Thrown when value is not compatible with <typeparamref name="T"/>
+        /// </exception>
+        public T As<T>() => _value is T val
+            ? val
+            : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
+
+        /// <summary>
+        /// Attempts to retrieve the value as <typeparamref name="T"/>
+        /// </summary>
+        public bool TryGet<T>([NotNullWhen(true)] out T result)
+        {
+            if (_value is T val)
+            {
+                result = val;
+                return true;
+            }
+
+            result = default!;
+            return false;
+        }
+
+        /// <summary>
+        /// Type-safe pattern matching with exhaustive case handling
+        /// </summary>
+        public TResult Match<TResult>(
+            Func<T1, TResult> t1Handler,
+            Func<T2, TResult> t2Handler,
+            Func<T3, TResult> t3Handler,
+            Func<T4, TResult> t4Handler,
+            Func<T5, TResult> t5Handler,
+            Func<T6, TResult> t6Handler,
+            Func<T7, TResult> t7Handler)
+        {
+            if (_typeIndices.Contains(0) && _value is T1 t1) return t1Handler(t1);
+            if (_typeIndices.Contains(1) && _value is T2 t2) return t2Handler(t2);
+            if (_typeIndices.Contains(2) && _value is T3 t3) return t3Handler(t3);
+            if (_typeIndices.Contains(3) && _value is T4 t4) return t4Handler(t4);
+            if (_typeIndices.Contains(4) && _value is T5 t5) return t5Handler(t5);
+            if (_typeIndices.Contains(5) && _value is T6 t6) return t6Handler(t6);
+            if (_typeIndices.Contains(6) && _value is T7 t7) return t7Handler(t7);
+            throw new InvalidOperationException("Invalid state");
+        }
+
+        /// <summary>
+        /// Executes type-specific action with exhaustive case handling
+        /// </summary>
+        public void Switch(
+            Action<T1> t1Action,
+            Action<T2> t2Action,
+            Action<T3> t3Action,
+            Action<T4> t4Action,
+            Action<T5> t5Action,
+            Action<T6> t6Action,
+            Action<T7> t7Action)
+        {
+            if (_typeIndices.Contains(0) && _value is T1 t1) { t1Action(t1); return; }
+            if (_typeIndices.Contains(1) && _value is T2 t2) { t2Action(t2); return; }
+            if (_typeIndices.Contains(2) && _value is T3 t3) { t3Action(t3); return; }
+            if (_typeIndices.Contains(3) && _value is T4 t4) { t4Action(t4); return; }
+            if (_typeIndices.Contains(4) && _value is T5 t5) { t5Action(t5); return; }
+            if (_typeIndices.Contains(5) && _value is T6 t6) { t6Action(t6); return; }
+            if (_typeIndices.Contains(6) && _value is T7 t7) { t7Action(t7); return; }
+            throw new InvalidOperationException("Invalid state");
+        }
+
+        /// <summary>
+        /// Returns all of the type parameters for which the stored value is assignable.
+        /// </summary>
+        public IEnumerable<Type> GetMatchingTypes()
+        {
+            if (_value is T1) yield return typeof(T1);
+            if (_value is T2) yield return typeof(T2);
+            if (_value is T3) yield return typeof(T3);
+            if (_value is T4) yield return typeof(T4);
+            if (_value is T5) yield return typeof(T5);
+            if (_value is T6) yield return typeof(T6);
+            if (_value is T7) yield return typeof(T7);
+        }
+
+        private string GetCastErrorMessage(Type targetType) =>
+            $"Cannot cast stored type {_value?.GetType().Name ?? "null"} to {targetType.Name}";
+
+        public bool Equals(AnyOf<T1, T2, T3, T4, T5, T6, T7> other) =>
+            _typeIndices.SetEquals(other._typeIndices) &&
+            Equals(_value, other._value);
+
+        public override bool Equals(object obj) =>
+            obj is AnyOf<T1, T2, T3, T4, T5, T6, T7> other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(_value, _typeIndices);
+
+        public static bool operator ==(AnyOf<T1, T2, T3, T4, T5, T6, T7> left, AnyOf<T1, T2, T3, T4, T5, T6, T7> right) =>
+            left.Equals(right);
+
+        public static bool operator !=(AnyOf<T1, T2, T3, T4, T5, T6, T7> left, AnyOf<T1, T2, T3, T4, T5, T6, T7> right) =>
+            !left.Equals(right);
+
+        public override string ToString() =>
+            _value?.ToString() ?? string.Empty;
+    }
+}

--- a/src/Cortex.Types/AnyOf/AnyOf8.cs
+++ b/src/Cortex.Types/AnyOf/AnyOf8.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Cortex.Types
+{
+    /// <summary>
+    /// Represents a value that can be any of eight specified types
+    /// </summary>
+    /// <typeparam name="T1">First possible type</typeparam>
+    /// <typeparam name="T2">Second possible type</typeparam>
+    /// <typeparam name="T3">Third possible type</typeparam>
+    /// <typeparam name="T4">Fourth possible type</typeparam>
+    /// <typeparam name="T5">Fifth possible type</typeparam>
+    /// <typeparam name="T6">Sixth possible type</typeparam>
+    /// <typeparam name="T7">Seventh possible type</typeparam>
+    /// <typeparam name="T8">Eighth possible type</typeparam>
+    public readonly struct AnyOf<T1, T2, T3, T4, T5, T6, T7, T8> : IEquatable<AnyOf<T1, T2, T3, T4, T5, T6, T7, T8>>, IAnyOf
+    {
+        private readonly object _value;
+        private readonly HashSet<int> _typeIndices;
+
+        /// <inheritdoc />
+        public object Value => _value;
+
+        /// <inheritdoc />
+        public IEnumerable<int> TypeIndices => _typeIndices;
+
+        private AnyOf(object value, HashSet<int> typeIndices) =>
+            (_value, _typeIndices) = (value, typeIndices);
+
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value) => new(value, new HashSet<int> { 0 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7, T8>(T2 value) => new(value, new HashSet<int> { 1 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7, T8>(T3 value) => new(value, new HashSet<int> { 2 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7, T8>(T4 value) => new(value, new HashSet<int> { 3 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7, T8>(T5 value) => new(value, new HashSet<int> { 4 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7, T8>(T6 value) => new(value, new HashSet<int> { 5 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7, T8>(T7 value) => new(value, new HashSet<int> { 6 });
+        public static implicit operator AnyOf<T1, T2, T3, T4, T5, T6, T7, T8>(T8 value) => new(value, new HashSet<int> { 7 });
+
+        /// <summary>
+        /// Checks if the contained value is of or derived from type <typeparamref name="T"/>
+        /// </summary>
+        public bool Is<T>() => _value is T;
+
+        /// <summary>
+        /// Returns the contained value as <typeparamref name="T"/>
+        /// </summary>
+        /// <exception cref="InvalidCastException">
+        /// Thrown when value is not compatible with <typeparamref name="T"/>
+        /// </exception>
+        public T As<T>() => _value is T val
+            ? val
+            : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
+
+        /// <summary>
+        /// Attempts to retrieve the value as <typeparamref name="T"/>
+        /// </summary>
+        public bool TryGet<T>([NotNullWhen(true)] out T result)
+        {
+            if (_value is T val)
+            {
+                result = val;
+                return true;
+            }
+
+            result = default!;
+            return false;
+        }
+
+        /// <summary>
+        /// Type-safe pattern matching with exhaustive case handling
+        /// </summary>
+        public TResult Match<TResult>(
+            Func<T1, TResult> t1Handler,
+            Func<T2, TResult> t2Handler,
+            Func<T3, TResult> t3Handler,
+            Func<T4, TResult> t4Handler,
+            Func<T5, TResult> t5Handler,
+            Func<T6, TResult> t6Handler,
+            Func<T7, TResult> t7Handler,
+            Func<T8, TResult> t8Handler)
+        {
+            if (_typeIndices.Contains(0) && _value is T1 t1) return t1Handler(t1);
+            if (_typeIndices.Contains(1) && _value is T2 t2) return t2Handler(t2);
+            if (_typeIndices.Contains(2) && _value is T3 t3) return t3Handler(t3);
+            if (_typeIndices.Contains(3) && _value is T4 t4) return t4Handler(t4);
+            if (_typeIndices.Contains(4) && _value is T5 t5) return t5Handler(t5);
+            if (_typeIndices.Contains(5) && _value is T6 t6) return t6Handler(t6);
+            if (_typeIndices.Contains(6) && _value is T7 t7) return t7Handler(t7);
+            if (_typeIndices.Contains(7) && _value is T8 t8) return t8Handler(t8);
+            throw new InvalidOperationException("Invalid state");
+        }
+
+        /// <summary>
+        /// Executes type-specific action with exhaustive case handling
+        /// </summary>
+        public void Switch(
+            Action<T1> t1Action,
+            Action<T2> t2Action,
+            Action<T3> t3Action,
+            Action<T4> t4Action,
+            Action<T5> t5Action,
+            Action<T6> t6Action,
+            Action<T7> t7Action,
+            Action<T8> t8Action)
+        {
+            if (_typeIndices.Contains(0) && _value is T1 t1) { t1Action(t1); return; }
+            if (_typeIndices.Contains(1) && _value is T2 t2) { t2Action(t2); return; }
+            if (_typeIndices.Contains(2) && _value is T3 t3) { t3Action(t3); return; }
+            if (_typeIndices.Contains(3) && _value is T4 t4) { t4Action(t4); return; }
+            if (_typeIndices.Contains(4) && _value is T5 t5) { t5Action(t5); return; }
+            if (_typeIndices.Contains(5) && _value is T6 t6) { t6Action(t6); return; }
+            if (_typeIndices.Contains(6) && _value is T7 t7) { t7Action(t7); return; }
+            if (_typeIndices.Contains(7) && _value is T8 t8) { t8Action(t8); return; }
+            throw new InvalidOperationException("Invalid state");
+        }
+
+        /// <summary>
+        /// Returns all of the type parameters for which the stored value is assignable.
+        /// </summary>
+        public IEnumerable<Type> GetMatchingTypes()
+        {
+            if (_value is T1) yield return typeof(T1);
+            if (_value is T2) yield return typeof(T2);
+            if (_value is T3) yield return typeof(T3);
+            if (_value is T4) yield return typeof(T4);
+            if (_value is T5) yield return typeof(T5);
+            if (_value is T6) yield return typeof(T6);
+            if (_value is T7) yield return typeof(T7);
+            if (_value is T8) yield return typeof(T8);
+        }
+
+        private string GetCastErrorMessage(Type targetType) =>
+            $"Cannot cast stored type {_value?.GetType().Name ?? "null"} to {targetType.Name}";
+
+        public bool Equals(AnyOf<T1, T2, T3, T4, T5, T6, T7, T8> other) =>
+            _typeIndices.SetEquals(other._typeIndices) &&
+            Equals(_value, other._value);
+
+        public override bool Equals(object obj) =>
+            obj is AnyOf<T1, T2, T3, T4, T5, T6, T7, T8> other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(_value, _typeIndices);
+
+        public static bool operator ==(AnyOf<T1, T2, T3, T4, T5, T6, T7, T8> left, AnyOf<T1, T2, T3, T4, T5, T6, T7, T8> right) =>
+            left.Equals(right);
+
+        public static bool operator !=(AnyOf<T1, T2, T3, T4, T5, T6, T7, T8> left, AnyOf<T1, T2, T3, T4, T5, T6, T7, T8> right) =>
+            !left.Equals(right);
+
+        public override string ToString() =>
+            _value?.ToString() ?? string.Empty;
+    }
+}

--- a/src/Cortex.Types/OneOf/OneOf5.cs
+++ b/src/Cortex.Types/OneOf/OneOf5.cs
@@ -1,19 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Cortex.Types
 {
     /// <summary>
-    /// Represents a value that can be one of three specified types
+    /// Represents a value that can be one of five specified types
     /// </summary>
     /// <typeparam name="T1">First possible type</typeparam>
     /// <typeparam name="T2">Second possible type</typeparam>
     /// <typeparam name="T3">Third possible type</typeparam>
-    public readonly struct OneOf<T1, T2, T3> : IEquatable<OneOf<T1, T2, T3>>, IOneOf
+    /// <typeparam name="T4">Fourth possible type</typeparam>
+    /// <typeparam name="T5">Fifth possible type</typeparam>
+    public readonly struct OneOf<T1, T2, T3, T4, T5> : IEquatable<OneOf<T1, T2, T3, T4, T5>>, IOneOf
     {
         private readonly object _value;
         private readonly int _typeIndex;
@@ -27,57 +25,30 @@ namespace Cortex.Types
         private OneOf(object value, int typeIndex) =>
             (_value, _typeIndex) = (value, typeIndex);
 
-        public static implicit operator OneOf<T1, T2, T3>(T1 value) => new(value, 0);
-        public static implicit operator OneOf<T1, T2, T3>(T2 value) => new(value, 1);
-        public static implicit operator OneOf<T1, T2, T3>(T3 value) => new(value, 2);
-
+        public static implicit operator OneOf<T1, T2, T3, T4, T5>(T1 value) => new(value, 0);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5>(T2 value) => new(value, 1);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5>(T3 value) => new(value, 2);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5>(T4 value) => new(value, 3);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5>(T5 value) => new(value, 4);
 
         /// <summary>
         /// Checks if the contained value is of or derived from type <typeparamref name="T"/>
         /// </summary>
-        /// <typeparam name="T">Type to check against</typeparam>
-        /// <returns>
-        /// True if value is exactly <typeparamref name="T"/> or derived from it
-        /// </returns>
-        /// <example>
-        /// <code>
-        /// OneOf&lt;Exception, string&gt; value = new ArgumentException();
-        /// value.Is&lt;Exception&gt;(); // true
-        /// value.Is&lt;ArgumentException&gt;(); // true
-        /// value.Is&lt;string&gt;(); // false
-        /// </code>
-        /// </example>
         public bool Is<T>() => _value is T;
 
         /// <summary>
         /// Returns the contained value as <typeparamref name="T"/>
         /// </summary>
-        /// <typeparam name="T">Target type</typeparam>
         /// <exception cref="InvalidCastException">
         /// Thrown when value is not compatible with <typeparamref name="T"/>
         /// </exception>
-        /// <example>
-        /// <code>
-        /// OneOf&lt;int, string&gt; value = "42";
-        /// string s = value.As&lt;string&gt;(); // "42"
-        /// int i = value.As&lt;int&gt;(); // throws
-        /// </code>
-        /// </example>
-        public T As<T>() => _value is T val ? val : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
-
+        public T As<T>() => _value is T val
+            ? val
+            : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
 
         /// <summary>
         /// Attempts to retrieve the value as <typeparamref name="T"/>
         /// </summary>
-        /// <param name="result">Out parameter receiving the value if successful</param>
-        /// <returns>True if value is compatible with <typeparamref name="T"/></returns>
-        /// <example>
-        /// <code>
-        /// if (value.TryGet(out string s)) {
-        ///     Console.WriteLine(s);
-        /// }
-        /// </code>
-        /// </example>
         public bool TryGet<T>([NotNullWhen(true)] out T result)
         {
             if (_value is T val)
@@ -96,11 +67,15 @@ namespace Cortex.Types
         public TResult Match<TResult>(
             Func<T1, TResult> t1Handler,
             Func<T2, TResult> t2Handler,
-            Func<T3, TResult> t3Handler) => _typeIndex switch
+            Func<T3, TResult> t3Handler,
+            Func<T4, TResult> t4Handler,
+            Func<T5, TResult> t5Handler) => _typeIndex switch
             {
                 0 => t1Handler((T1)_value),
                 1 => t2Handler((T2)_value),
                 2 => t3Handler((T3)_value),
+                3 => t4Handler((T4)_value),
+                4 => t5Handler((T5)_value),
                 _ => throw new InvalidOperationException("Invalid state")
             };
 
@@ -110,13 +85,17 @@ namespace Cortex.Types
         public void Switch(
             Action<T1> t1Action,
             Action<T2> t2Action,
-            Action<T3> t3Action)
+            Action<T3> t3Action,
+            Action<T4> t4Action,
+            Action<T5> t5Action)
         {
             switch (_typeIndex)
             {
                 case 0: t1Action((T1)_value); break;
                 case 1: t2Action((T2)_value); break;
                 case 2: t3Action((T3)_value); break;
+                case 3: t4Action((T4)_value); break;
+                case 4: t5Action((T5)_value); break;
                 default: throw new InvalidOperationException("Invalid state");
             }
         }
@@ -124,20 +103,20 @@ namespace Cortex.Types
         private string GetCastErrorMessage(Type targetType) =>
             $"Cannot cast stored type {_value?.GetType().Name ?? "null"} to {targetType.Name}";
 
-        public bool Equals(OneOf<T1, T2, T3> other) =>
-                   _typeIndex == other._typeIndex &&
-                   Equals(_value, other._value);
+        public bool Equals(OneOf<T1, T2, T3, T4, T5> other) =>
+            _typeIndex == other._typeIndex &&
+            Equals(_value, other._value);
 
         public override bool Equals(object obj) =>
-            obj is OneOf<T1, T2, T3> other && Equals(other);
+            obj is OneOf<T1, T2, T3, T4, T5> other && Equals(other);
 
         public override int GetHashCode() =>
             HashCode.Combine(_value, _typeIndex);
 
-        public static bool operator ==(OneOf<T1, T2, T3> left, OneOf<T1, T2, T3> right) =>
+        public static bool operator ==(OneOf<T1, T2, T3, T4, T5> left, OneOf<T1, T2, T3, T4, T5> right) =>
             left.Equals(right);
 
-        public static bool operator !=(OneOf<T1, T2, T3> left, OneOf<T1, T2, T3> right) =>
+        public static bool operator !=(OneOf<T1, T2, T3, T4, T5> left, OneOf<T1, T2, T3, T4, T5> right) =>
             !left.Equals(right);
 
         public override string ToString() =>

--- a/src/Cortex.Types/OneOf/OneOf6.cs
+++ b/src/Cortex.Types/OneOf/OneOf6.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Cortex.Types
 {
     /// <summary>
-    /// Represents a value that can be one of three specified types
+    /// Represents a value that can be one of six specified types
     /// </summary>
     /// <typeparam name="T1">First possible type</typeparam>
     /// <typeparam name="T2">Second possible type</typeparam>
     /// <typeparam name="T3">Third possible type</typeparam>
-    public readonly struct OneOf<T1, T2, T3> : IEquatable<OneOf<T1, T2, T3>>, IOneOf
+    /// <typeparam name="T4">Fourth possible type</typeparam>
+    /// <typeparam name="T5">Fifth possible type</typeparam>
+    /// <typeparam name="T6">Sixth possible type</typeparam>
+    public readonly struct OneOf<T1, T2, T3, T4, T5, T6> : IEquatable<OneOf<T1, T2, T3, T4, T5, T6>>, IOneOf
     {
         private readonly object _value;
         private readonly int _typeIndex;
@@ -27,57 +26,31 @@ namespace Cortex.Types
         private OneOf(object value, int typeIndex) =>
             (_value, _typeIndex) = (value, typeIndex);
 
-        public static implicit operator OneOf<T1, T2, T3>(T1 value) => new(value, 0);
-        public static implicit operator OneOf<T1, T2, T3>(T2 value) => new(value, 1);
-        public static implicit operator OneOf<T1, T2, T3>(T3 value) => new(value, 2);
-
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6>(T1 value) => new(value, 0);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6>(T2 value) => new(value, 1);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6>(T3 value) => new(value, 2);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6>(T4 value) => new(value, 3);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6>(T5 value) => new(value, 4);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6>(T6 value) => new(value, 5);
 
         /// <summary>
         /// Checks if the contained value is of or derived from type <typeparamref name="T"/>
         /// </summary>
-        /// <typeparam name="T">Type to check against</typeparam>
-        /// <returns>
-        /// True if value is exactly <typeparamref name="T"/> or derived from it
-        /// </returns>
-        /// <example>
-        /// <code>
-        /// OneOf&lt;Exception, string&gt; value = new ArgumentException();
-        /// value.Is&lt;Exception&gt;(); // true
-        /// value.Is&lt;ArgumentException&gt;(); // true
-        /// value.Is&lt;string&gt;(); // false
-        /// </code>
-        /// </example>
         public bool Is<T>() => _value is T;
 
         /// <summary>
         /// Returns the contained value as <typeparamref name="T"/>
         /// </summary>
-        /// <typeparam name="T">Target type</typeparam>
         /// <exception cref="InvalidCastException">
         /// Thrown when value is not compatible with <typeparamref name="T"/>
         /// </exception>
-        /// <example>
-        /// <code>
-        /// OneOf&lt;int, string&gt; value = "42";
-        /// string s = value.As&lt;string&gt;(); // "42"
-        /// int i = value.As&lt;int&gt;(); // throws
-        /// </code>
-        /// </example>
-        public T As<T>() => _value is T val ? val : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
-
+        public T As<T>() => _value is T val
+            ? val
+            : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
 
         /// <summary>
         /// Attempts to retrieve the value as <typeparamref name="T"/>
         /// </summary>
-        /// <param name="result">Out parameter receiving the value if successful</param>
-        /// <returns>True if value is compatible with <typeparamref name="T"/></returns>
-        /// <example>
-        /// <code>
-        /// if (value.TryGet(out string s)) {
-        ///     Console.WriteLine(s);
-        /// }
-        /// </code>
-        /// </example>
         public bool TryGet<T>([NotNullWhen(true)] out T result)
         {
             if (_value is T val)
@@ -96,11 +69,17 @@ namespace Cortex.Types
         public TResult Match<TResult>(
             Func<T1, TResult> t1Handler,
             Func<T2, TResult> t2Handler,
-            Func<T3, TResult> t3Handler) => _typeIndex switch
+            Func<T3, TResult> t3Handler,
+            Func<T4, TResult> t4Handler,
+            Func<T5, TResult> t5Handler,
+            Func<T6, TResult> t6Handler) => _typeIndex switch
             {
                 0 => t1Handler((T1)_value),
                 1 => t2Handler((T2)_value),
                 2 => t3Handler((T3)_value),
+                3 => t4Handler((T4)_value),
+                4 => t5Handler((T5)_value),
+                5 => t6Handler((T6)_value),
                 _ => throw new InvalidOperationException("Invalid state")
             };
 
@@ -110,13 +89,19 @@ namespace Cortex.Types
         public void Switch(
             Action<T1> t1Action,
             Action<T2> t2Action,
-            Action<T3> t3Action)
+            Action<T3> t3Action,
+            Action<T4> t4Action,
+            Action<T5> t5Action,
+            Action<T6> t6Action)
         {
             switch (_typeIndex)
             {
                 case 0: t1Action((T1)_value); break;
                 case 1: t2Action((T2)_value); break;
                 case 2: t3Action((T3)_value); break;
+                case 3: t4Action((T4)_value); break;
+                case 4: t5Action((T5)_value); break;
+                case 5: t6Action((T6)_value); break;
                 default: throw new InvalidOperationException("Invalid state");
             }
         }
@@ -124,20 +109,20 @@ namespace Cortex.Types
         private string GetCastErrorMessage(Type targetType) =>
             $"Cannot cast stored type {_value?.GetType().Name ?? "null"} to {targetType.Name}";
 
-        public bool Equals(OneOf<T1, T2, T3> other) =>
-                   _typeIndex == other._typeIndex &&
-                   Equals(_value, other._value);
+        public bool Equals(OneOf<T1, T2, T3, T4, T5, T6> other) =>
+            _typeIndex == other._typeIndex &&
+            Equals(_value, other._value);
 
         public override bool Equals(object obj) =>
-            obj is OneOf<T1, T2, T3> other && Equals(other);
+            obj is OneOf<T1, T2, T3, T4, T5, T6> other && Equals(other);
 
         public override int GetHashCode() =>
             HashCode.Combine(_value, _typeIndex);
 
-        public static bool operator ==(OneOf<T1, T2, T3> left, OneOf<T1, T2, T3> right) =>
+        public static bool operator ==(OneOf<T1, T2, T3, T4, T5, T6> left, OneOf<T1, T2, T3, T4, T5, T6> right) =>
             left.Equals(right);
 
-        public static bool operator !=(OneOf<T1, T2, T3> left, OneOf<T1, T2, T3> right) =>
+        public static bool operator !=(OneOf<T1, T2, T3, T4, T5, T6> left, OneOf<T1, T2, T3, T4, T5, T6> right) =>
             !left.Equals(right);
 
         public override string ToString() =>

--- a/src/Cortex.Types/OneOf/OneOf7.cs
+++ b/src/Cortex.Types/OneOf/OneOf7.cs
@@ -1,19 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Cortex.Types
 {
     /// <summary>
-    /// Represents a value that can be one of three specified types
+    /// Represents a value that can be one of seven specified types
     /// </summary>
     /// <typeparam name="T1">First possible type</typeparam>
     /// <typeparam name="T2">Second possible type</typeparam>
     /// <typeparam name="T3">Third possible type</typeparam>
-    public readonly struct OneOf<T1, T2, T3> : IEquatable<OneOf<T1, T2, T3>>, IOneOf
+    /// <typeparam name="T4">Fourth possible type</typeparam>
+    /// <typeparam name="T5">Fifth possible type</typeparam>
+    /// <typeparam name="T6">Sixth possible type</typeparam>
+    /// <typeparam name="T7">Seventh possible type</typeparam>
+    public readonly struct OneOf<T1, T2, T3, T4, T5, T6, T7> : IEquatable<OneOf<T1, T2, T3, T4, T5, T6, T7>>, IOneOf
     {
         private readonly object _value;
         private readonly int _typeIndex;
@@ -27,57 +27,32 @@ namespace Cortex.Types
         private OneOf(object value, int typeIndex) =>
             (_value, _typeIndex) = (value, typeIndex);
 
-        public static implicit operator OneOf<T1, T2, T3>(T1 value) => new(value, 0);
-        public static implicit operator OneOf<T1, T2, T3>(T2 value) => new(value, 1);
-        public static implicit operator OneOf<T1, T2, T3>(T3 value) => new(value, 2);
-
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7>(T1 value) => new(value, 0);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7>(T2 value) => new(value, 1);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7>(T3 value) => new(value, 2);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7>(T4 value) => new(value, 3);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7>(T5 value) => new(value, 4);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7>(T6 value) => new(value, 5);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7>(T7 value) => new(value, 6);
 
         /// <summary>
         /// Checks if the contained value is of or derived from type <typeparamref name="T"/>
         /// </summary>
-        /// <typeparam name="T">Type to check against</typeparam>
-        /// <returns>
-        /// True if value is exactly <typeparamref name="T"/> or derived from it
-        /// </returns>
-        /// <example>
-        /// <code>
-        /// OneOf&lt;Exception, string&gt; value = new ArgumentException();
-        /// value.Is&lt;Exception&gt;(); // true
-        /// value.Is&lt;ArgumentException&gt;(); // true
-        /// value.Is&lt;string&gt;(); // false
-        /// </code>
-        /// </example>
         public bool Is<T>() => _value is T;
 
         /// <summary>
         /// Returns the contained value as <typeparamref name="T"/>
         /// </summary>
-        /// <typeparam name="T">Target type</typeparam>
         /// <exception cref="InvalidCastException">
         /// Thrown when value is not compatible with <typeparamref name="T"/>
         /// </exception>
-        /// <example>
-        /// <code>
-        /// OneOf&lt;int, string&gt; value = "42";
-        /// string s = value.As&lt;string&gt;(); // "42"
-        /// int i = value.As&lt;int&gt;(); // throws
-        /// </code>
-        /// </example>
-        public T As<T>() => _value is T val ? val : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
-
+        public T As<T>() => _value is T val
+            ? val
+            : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
 
         /// <summary>
         /// Attempts to retrieve the value as <typeparamref name="T"/>
         /// </summary>
-        /// <param name="result">Out parameter receiving the value if successful</param>
-        /// <returns>True if value is compatible with <typeparamref name="T"/></returns>
-        /// <example>
-        /// <code>
-        /// if (value.TryGet(out string s)) {
-        ///     Console.WriteLine(s);
-        /// }
-        /// </code>
-        /// </example>
         public bool TryGet<T>([NotNullWhen(true)] out T result)
         {
             if (_value is T val)
@@ -96,11 +71,19 @@ namespace Cortex.Types
         public TResult Match<TResult>(
             Func<T1, TResult> t1Handler,
             Func<T2, TResult> t2Handler,
-            Func<T3, TResult> t3Handler) => _typeIndex switch
+            Func<T3, TResult> t3Handler,
+            Func<T4, TResult> t4Handler,
+            Func<T5, TResult> t5Handler,
+            Func<T6, TResult> t6Handler,
+            Func<T7, TResult> t7Handler) => _typeIndex switch
             {
                 0 => t1Handler((T1)_value),
                 1 => t2Handler((T2)_value),
                 2 => t3Handler((T3)_value),
+                3 => t4Handler((T4)_value),
+                4 => t5Handler((T5)_value),
+                5 => t6Handler((T6)_value),
+                6 => t7Handler((T7)_value),
                 _ => throw new InvalidOperationException("Invalid state")
             };
 
@@ -110,13 +93,21 @@ namespace Cortex.Types
         public void Switch(
             Action<T1> t1Action,
             Action<T2> t2Action,
-            Action<T3> t3Action)
+            Action<T3> t3Action,
+            Action<T4> t4Action,
+            Action<T5> t5Action,
+            Action<T6> t6Action,
+            Action<T7> t7Action)
         {
             switch (_typeIndex)
             {
                 case 0: t1Action((T1)_value); break;
                 case 1: t2Action((T2)_value); break;
                 case 2: t3Action((T3)_value); break;
+                case 3: t4Action((T4)_value); break;
+                case 4: t5Action((T5)_value); break;
+                case 5: t6Action((T6)_value); break;
+                case 6: t7Action((T7)_value); break;
                 default: throw new InvalidOperationException("Invalid state");
             }
         }
@@ -124,20 +115,20 @@ namespace Cortex.Types
         private string GetCastErrorMessage(Type targetType) =>
             $"Cannot cast stored type {_value?.GetType().Name ?? "null"} to {targetType.Name}";
 
-        public bool Equals(OneOf<T1, T2, T3> other) =>
-                   _typeIndex == other._typeIndex &&
-                   Equals(_value, other._value);
+        public bool Equals(OneOf<T1, T2, T3, T4, T5, T6, T7> other) =>
+            _typeIndex == other._typeIndex &&
+            Equals(_value, other._value);
 
         public override bool Equals(object obj) =>
-            obj is OneOf<T1, T2, T3> other && Equals(other);
+            obj is OneOf<T1, T2, T3, T4, T5, T6, T7> other && Equals(other);
 
         public override int GetHashCode() =>
             HashCode.Combine(_value, _typeIndex);
 
-        public static bool operator ==(OneOf<T1, T2, T3> left, OneOf<T1, T2, T3> right) =>
+        public static bool operator ==(OneOf<T1, T2, T3, T4, T5, T6, T7> left, OneOf<T1, T2, T3, T4, T5, T6, T7> right) =>
             left.Equals(right);
 
-        public static bool operator !=(OneOf<T1, T2, T3> left, OneOf<T1, T2, T3> right) =>
+        public static bool operator !=(OneOf<T1, T2, T3, T4, T5, T6, T7> left, OneOf<T1, T2, T3, T4, T5, T6, T7> right) =>
             !left.Equals(right);
 
         public override string ToString() =>

--- a/src/Cortex.Types/OneOf/OneOf8.cs
+++ b/src/Cortex.Types/OneOf/OneOf8.cs
@@ -1,24 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Cortex.Types
 {
     /// <summary>
-    /// Represents a value that can be one of three specified types
+    /// Represents a value that can be one of eight specified types
     /// </summary>
     /// <typeparam name="T1">First possible type</typeparam>
     /// <typeparam name="T2">Second possible type</typeparam>
     /// <typeparam name="T3">Third possible type</typeparam>
-    /// <typeparam name="T4">Forth possible type</typeparam>
-    public readonly struct OneOf<T1, T2, T3, T4> : IEquatable<OneOf<T1, T2, T3, T4>>, IOneOf
+    /// <typeparam name="T4">Fourth possible type</typeparam>
+    /// <typeparam name="T5">Fifth possible type</typeparam>
+    /// <typeparam name="T6">Sixth possible type</typeparam>
+    /// <typeparam name="T7">Seventh possible type</typeparam>
+    /// <typeparam name="T8">Eighth possible type</typeparam>
+    public readonly struct OneOf<T1, T2, T3, T4, T5, T6, T7, T8> : IEquatable<OneOf<T1, T2, T3, T4, T5, T6, T7, T8>>, IOneOf
     {
         private readonly object _value;
         private readonly int _typeIndex;
-
 
         /// <inheritdoc />
         public object Value => _value;
@@ -29,58 +28,33 @@ namespace Cortex.Types
         private OneOf(object value, int typeIndex) =>
             (_value, _typeIndex) = (value, typeIndex);
 
-        public static implicit operator OneOf<T1, T2, T3, T4>(T1 value) => new(value, 0);
-        public static implicit operator OneOf<T1, T2, T3, T4>(T2 value) => new(value, 1);
-        public static implicit operator OneOf<T1, T2, T3, T4>(T3 value) => new(value, 2);
-        public static implicit operator OneOf<T1, T2, T3, T4>(T4 value) => new(value, 3);
-
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value) => new(value, 0);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7, T8>(T2 value) => new(value, 1);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7, T8>(T3 value) => new(value, 2);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7, T8>(T4 value) => new(value, 3);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7, T8>(T5 value) => new(value, 4);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7, T8>(T6 value) => new(value, 5);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7, T8>(T7 value) => new(value, 6);
+        public static implicit operator OneOf<T1, T2, T3, T4, T5, T6, T7, T8>(T8 value) => new(value, 7);
 
         /// <summary>
         /// Checks if the contained value is of or derived from type <typeparamref name="T"/>
         /// </summary>
-        /// <typeparam name="T">Type to check against</typeparam>
-        /// <returns>
-        /// True if value is exactly <typeparamref name="T"/> or derived from it
-        /// </returns>
-        /// <example>
-        /// <code>
-        /// OneOf&lt;Exception, string&gt; value = new ArgumentException();
-        /// value.Is&lt;Exception&gt;(); // true
-        /// value.Is&lt;ArgumentException&gt;(); // true
-        /// value.Is&lt;string&gt;(); // false
-        /// </code>
-        /// </example>
         public bool Is<T>() => _value is T;
 
         /// <summary>
         /// Returns the contained value as <typeparamref name="T"/>
         /// </summary>
-        /// <typeparam name="T">Target type</typeparam>
         /// <exception cref="InvalidCastException">
         /// Thrown when value is not compatible with <typeparamref name="T"/>
         /// </exception>
-        /// <example>
-        /// <code>
-        /// OneOf&lt;int, string&gt; value = "42";
-        /// string s = value.As&lt;string&gt;(); // "42"
-        /// int i = value.As&lt;int&gt;(); // throws
-        /// </code>
-        /// </example>
-        public T As<T>() => _value is T val ? val : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
-
+        public T As<T>() => _value is T val
+            ? val
+            : throw new InvalidCastException(GetCastErrorMessage(typeof(T)));
 
         /// <summary>
         /// Attempts to retrieve the value as <typeparamref name="T"/>
         /// </summary>
-        /// <param name="result">Out parameter receiving the value if successful</param>
-        /// <returns>True if value is compatible with <typeparamref name="T"/></returns>
-        /// <example>
-        /// <code>
-        /// if (value.TryGet(out string s)) {
-        ///     Console.WriteLine(s);
-        /// }
-        /// </code>
-        /// </example>
         public bool TryGet<T>([NotNullWhen(true)] out T result)
         {
             if (_value is T val)
@@ -100,12 +74,20 @@ namespace Cortex.Types
             Func<T1, TResult> t1Handler,
             Func<T2, TResult> t2Handler,
             Func<T3, TResult> t3Handler,
-            Func<T4, TResult> t4Handler) => _typeIndex switch
+            Func<T4, TResult> t4Handler,
+            Func<T5, TResult> t5Handler,
+            Func<T6, TResult> t6Handler,
+            Func<T7, TResult> t7Handler,
+            Func<T8, TResult> t8Handler) => _typeIndex switch
             {
                 0 => t1Handler((T1)_value),
                 1 => t2Handler((T2)_value),
                 2 => t3Handler((T3)_value),
                 3 => t4Handler((T4)_value),
+                4 => t5Handler((T5)_value),
+                5 => t6Handler((T6)_value),
+                6 => t7Handler((T7)_value),
+                7 => t8Handler((T8)_value),
                 _ => throw new InvalidOperationException("Invalid state")
             };
 
@@ -116,7 +98,11 @@ namespace Cortex.Types
             Action<T1> t1Action,
             Action<T2> t2Action,
             Action<T3> t3Action,
-            Action<T4> t4Action)
+            Action<T4> t4Action,
+            Action<T5> t5Action,
+            Action<T6> t6Action,
+            Action<T7> t7Action,
+            Action<T8> t8Action)
         {
             switch (_typeIndex)
             {
@@ -124,6 +110,10 @@ namespace Cortex.Types
                 case 1: t2Action((T2)_value); break;
                 case 2: t3Action((T3)_value); break;
                 case 3: t4Action((T4)_value); break;
+                case 4: t5Action((T5)_value); break;
+                case 5: t6Action((T6)_value); break;
+                case 6: t7Action((T7)_value); break;
+                case 7: t8Action((T8)_value); break;
                 default: throw new InvalidOperationException("Invalid state");
             }
         }
@@ -131,20 +121,20 @@ namespace Cortex.Types
         private string GetCastErrorMessage(Type targetType) =>
             $"Cannot cast stored type {_value?.GetType().Name ?? "null"} to {targetType.Name}";
 
-        public bool Equals(OneOf<T1, T2, T3, T4> other) =>
-                          _typeIndex == other._typeIndex &&
-                          Equals(_value, other._value);
+        public bool Equals(OneOf<T1, T2, T3, T4, T5, T6, T7, T8> other) =>
+            _typeIndex == other._typeIndex &&
+            Equals(_value, other._value);
 
         public override bool Equals(object obj) =>
-            obj is OneOf<T1, T2, T3, T4> other && Equals(other);
+            obj is OneOf<T1, T2, T3, T4, T5, T6, T7, T8> other && Equals(other);
 
         public override int GetHashCode() =>
             HashCode.Combine(_value, _typeIndex);
 
-        public static bool operator ==(OneOf<T1, T2, T3, T4> left, OneOf<T1, T2, T3, T4> right) =>
+        public static bool operator ==(OneOf<T1, T2, T3, T4, T5, T6, T7, T8> left, OneOf<T1, T2, T3, T4, T5, T6, T7, T8> right) =>
             left.Equals(right);
 
-        public static bool operator !=(OneOf<T1, T2, T3, T4> left, OneOf<T1, T2, T3, T4> right) =>
+        public static bool operator !=(OneOf<T1, T2, T3, T4, T5, T6, T7, T8> left, OneOf<T1, T2, T3, T4, T5, T6, T7, T8> right) =>
             !left.Equals(right);
 
         public override string ToString() =>

--- a/src/Cortex.Types/Result/IResult.cs
+++ b/src/Cortex.Types/Result/IResult.cs
@@ -1,0 +1,43 @@
+namespace Cortex.Types
+{
+    /// <summary>
+    /// Base interface for all Result types providing common functionality
+    /// </summary>
+    public interface IResult
+    {
+        /// <summary>
+        /// Gets whether the result represents a successful operation
+        /// </summary>
+        bool IsSuccess { get; }
+
+        /// <summary>
+        /// Gets whether the result represents a failed operation
+        /// </summary>
+        bool IsFailure { get; }
+    }
+
+    /// <summary>
+    /// Interface for Result types that carry a value
+    /// </summary>
+    /// <typeparam name="TValue">Type of the success value</typeparam>
+    public interface IResult<out TValue> : IResult
+    {
+        /// <summary>
+        /// Gets the success value. Throws if the result is a failure.
+        /// </summary>
+        TValue Value { get; }
+    }
+
+    /// <summary>
+    /// Interface for Result types that carry both value and error
+    /// </summary>
+    /// <typeparam name="TValue">Type of the success value</typeparam>
+    /// <typeparam name="TError">Type of the error value</typeparam>
+    public interface IResult<out TValue, out TError> : IResult<TValue>
+    {
+        /// <summary>
+        /// Gets the error value. Throws if the result is a success.
+        /// </summary>
+        TError Error { get; }
+    }
+}

--- a/src/Cortex.Types/Result/Result.cs
+++ b/src/Cortex.Types/Result/Result.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Cortex.Types
+{
+    /// <summary>
+    /// Represents the result of an operation that can succeed with a value or fail with a built-in error
+    /// </summary>
+    /// <typeparam name="T">Type of the success value</typeparam>
+    public readonly struct Result<T> : IEquatable<Result<T>>, IResult<T, ResultError>
+    {
+        private readonly T _value;
+        private readonly ResultError _error;
+        private readonly bool _isSuccess;
+
+        /// <inheritdoc />
+        public bool IsSuccess => _isSuccess;
+
+        /// <inheritdoc />
+        public bool IsFailure => !_isSuccess;
+
+        /// <inheritdoc />
+        /// <exception cref="InvalidOperationException">Thrown when accessing Value on a failed result</exception>
+        public T Value => _isSuccess
+            ? _value
+            : throw new InvalidOperationException(
+                $"Cannot access Value on a failed Result. Error: {_error}");
+
+        /// <inheritdoc />
+        /// <exception cref="InvalidOperationException">Thrown when accessing Error on a successful result</exception>
+        public ResultError Error => !_isSuccess
+            ? _error
+            : throw new InvalidOperationException(
+                "Cannot access Error on a successful Result");
+
+        private Result(T value, ResultError error, bool isSuccess)
+        {
+            _value = value;
+            _error = error;
+            _isSuccess = isSuccess;
+        }
+
+        /// <summary>
+        /// Creates a successful result with the specified value
+        /// </summary>
+        /// <param name="value">The success value</param>
+        /// <returns>A successful Result</returns>
+        public static Result<T> Success(T value) =>
+            new(value, default, true);
+
+        /// <summary>
+        /// Creates a failed result with the specified error
+        /// </summary>
+        /// <param name="error">The error</param>
+        /// <returns>A failed Result</returns>
+        public static Result<T> Failure(ResultError error) =>
+            new(default, error ?? throw new ArgumentNullException(nameof(error)), false);
+
+        /// <summary>
+        /// Creates a failed result with the specified error message
+        /// </summary>
+        /// <param name="errorMessage">The error message</param>
+        /// <returns>A failed Result</returns>
+        public static Result<T> Failure(string errorMessage) =>
+            new(default, new ResultError(errorMessage), false);
+
+        /// <summary>
+        /// Creates a failed result from an exception
+        /// </summary>
+        /// <param name="exception">The exception</param>
+        /// <returns>A failed Result</returns>
+        public static Result<T> Failure(Exception exception) =>
+            new(default, ResultError.FromException(exception), false);
+
+        /// <summary>
+        /// Implicit conversion from value to successful Result
+        /// </summary>
+        public static implicit operator Result<T>(T value) => Success(value);
+
+        /// <summary>
+        /// Implicit conversion from ResultError to failed Result
+        /// </summary>
+        public static implicit operator Result<T>(ResultError error) => Failure(error);
+
+        /// <summary>
+        /// Attempts to get the success value
+        /// </summary>
+        /// <param name="value">The success value if successful</param>
+        /// <returns>True if successful, false otherwise</returns>
+#if !NETSTANDARD2_0
+        public bool TryGetValue([NotNullWhen(true)] out T value)
+#else
+        public bool TryGetValue(out T value)
+#endif
+        {
+            if (_isSuccess)
+            {
+                value = _value;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Attempts to get the error
+        /// </summary>
+        /// <param name="error">The error if failed</param>
+        /// <returns>True if failed, false otherwise</returns>
+#if !NETSTANDARD2_0
+        public bool TryGetError([NotNullWhen(true)] out ResultError error)
+#else
+        public bool TryGetError(out ResultError error)
+#endif
+        {
+            if (!_isSuccess)
+            {
+                error = _error;
+                return true;
+            }
+
+            error = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the value if successful, otherwise returns the specified default value
+        /// </summary>
+        /// <param name="defaultValue">Default value to return on failure</param>
+        /// <returns>The success value or default</returns>
+        public T GetValueOrDefault(T defaultValue = default) =>
+            _isSuccess ? _value : defaultValue;
+
+        /// <summary>
+        /// Gets the value if successful, otherwise returns the result of the factory function
+        /// </summary>
+        /// <param name="defaultFactory">Factory function to create default value</param>
+        /// <returns>The success value or factory result</returns>
+        public T GetValueOrDefault(Func<T> defaultFactory) =>
+            _isSuccess ? _value : defaultFactory();
+
+        /// <summary>
+        /// Gets the value if successful, otherwise returns the result of the error handler
+        /// </summary>
+        /// <param name="errorHandler">Handler that receives the error and returns a default value</param>
+        /// <returns>The success value or handler result</returns>
+        public T GetValueOrDefault(Func<ResultError, T> errorHandler) =>
+            _isSuccess ? _value : errorHandler(_error);
+
+        /// <summary>
+        /// Pattern matches on the result, executing the appropriate handler
+        /// </summary>
+        /// <typeparam name="TResult">Return type of handlers</typeparam>
+        /// <param name="onSuccess">Handler for success case</param>
+        /// <param name="onFailure">Handler for failure case</param>
+        /// <returns>Result of the executed handler</returns>
+        public TResult Match<TResult>(
+            Func<T, TResult> onSuccess,
+            Func<ResultError, TResult> onFailure) =>
+            _isSuccess ? onSuccess(_value) : onFailure(_error);
+
+        /// <summary>
+        /// Executes the appropriate action based on success or failure
+        /// </summary>
+        /// <param name="onSuccess">Action for success case</param>
+        /// <param name="onFailure">Action for failure case</param>
+        public void Switch(
+            Action<T> onSuccess,
+            Action<ResultError> onFailure)
+        {
+            if (_isSuccess)
+                onSuccess(_value);
+            else
+                onFailure(_error);
+        }
+
+        /// <summary>
+        /// Transforms the success value using the specified mapping function
+        /// </summary>
+        /// <typeparam name="TNew">Type of the new value</typeparam>
+        /// <param name="mapper">Function to transform the value</param>
+        /// <returns>A new Result with the transformed value or the original error</returns>
+        public Result<TNew> Map<TNew>(Func<T, TNew> mapper) =>
+            _isSuccess
+                ? Result<TNew>.Success(mapper(_value))
+                : Result<TNew>.Failure(_error);
+
+        /// <summary>
+        /// Transforms the error using the specified mapping function
+        /// </summary>
+        /// <param name="mapper">Function to transform the error</param>
+        /// <returns>A new Result with the original value or transformed error</returns>
+        public Result<T> MapError(Func<ResultError, ResultError> mapper) =>
+            _isSuccess
+                ? this
+                : Result<T>.Failure(mapper(_error));
+
+        /// <summary>
+        /// Chains another operation that returns a Result
+        /// </summary>
+        /// <typeparam name="TNew">Type of the new value</typeparam>
+        /// <param name="binder">Function that returns a new Result</param>
+        /// <returns>The new Result or the original error</returns>
+        public Result<TNew> Bind<TNew>(Func<T, Result<TNew>> binder) =>
+            _isSuccess ? binder(_value) : Result<TNew>.Failure(_error);
+
+        /// <summary>
+        /// Executes an action on success, returning the original result
+        /// </summary>
+        /// <param name="action">Action to execute on success</param>
+        /// <returns>The original Result</returns>
+        public Result<T> Tap(Action<T> action)
+        {
+            if (_isSuccess)
+                action(_value);
+            return this;
+        }
+
+        /// <summary>
+        /// Executes an action on failure, returning the original result
+        /// </summary>
+        /// <param name="action">Action to execute on failure</param>
+        /// <returns>The original Result</returns>
+        public Result<T> TapError(Action<ResultError> action)
+        {
+            if (!_isSuccess)
+                action(_error);
+            return this;
+        }
+
+        /// <summary>
+        /// Ensures a condition is met, converting to failure if not
+        /// </summary>
+        /// <param name="predicate">Condition to check</param>
+        /// <param name="error">Error to use if condition fails</param>
+        /// <returns>The original Result or a failed Result</returns>
+        public Result<T> Ensure(Func<T, bool> predicate, ResultError error) =>
+            _isSuccess && !predicate(_value)
+                ? Result<T>.Failure(error)
+                : this;
+
+        /// <summary>
+        /// Ensures a condition is met, converting to failure if not
+        /// </summary>
+        /// <param name="predicate">Condition to check</param>
+        /// <param name="errorMessage">Error message to use if condition fails</param>
+        /// <returns>The original Result or a failed Result</returns>
+        public Result<T> Ensure(Func<T, bool> predicate, string errorMessage) =>
+            Ensure(predicate, new ResultError(errorMessage));
+
+        public bool Equals(Result<T> other) =>
+            _isSuccess == other._isSuccess &&
+            Equals(_value, other._value) &&
+            Equals(_error, other._error);
+
+        public override bool Equals(object obj) =>
+            obj is Result<T> other && Equals(other);
+
+        public override int GetHashCode()
+        {
+#if NETSTANDARD2_0
+            unchecked
+            {
+                var hashCode = _isSuccess.GetHashCode();
+                hashCode = (hashCode * 397) ^ (_value?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (_error?.GetHashCode() ?? 0);
+                return hashCode;
+            }
+#else
+            return HashCode.Combine(_isSuccess, _value, _error);
+#endif
+        }
+
+        public static bool operator ==(Result<T> left, Result<T> right) =>
+            left.Equals(right);
+
+        public static bool operator !=(Result<T> left, Result<T> right) =>
+            !left.Equals(right);
+
+        public override string ToString() =>
+            _isSuccess
+                ? $"Success({_value})"
+                : $"Failure({_error})";
+    }
+}

--- a/src/Cortex.Types/Result/Result2.cs
+++ b/src/Cortex.Types/Result/Result2.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Cortex.Types
+{
+    /// <summary>
+    /// Represents the result of an operation that can succeed with a value or fail with a custom error type
+    /// </summary>
+    /// <typeparam name="TValue">Type of the success value</typeparam>
+    /// <typeparam name="TError">Type of the error value</typeparam>
+    public readonly struct Result<TValue, TError> : IEquatable<Result<TValue, TError>>, IResult<TValue, TError>
+    {
+        private readonly TValue _value;
+        private readonly TError _error;
+        private readonly bool _isSuccess;
+
+        /// <inheritdoc />
+        public bool IsSuccess => _isSuccess;
+
+        /// <inheritdoc />
+        public bool IsFailure => !_isSuccess;
+
+        /// <inheritdoc />
+        /// <exception cref="InvalidOperationException">Thrown when accessing Value on a failed result</exception>
+        public TValue Value => _isSuccess
+            ? _value
+            : throw new InvalidOperationException(
+                $"Cannot access Value on a failed Result. Error: {_error}");
+
+        /// <inheritdoc />
+        /// <exception cref="InvalidOperationException">Thrown when accessing Error on a successful result</exception>
+        public TError Error => !_isSuccess
+            ? _error
+            : throw new InvalidOperationException(
+                "Cannot access Error on a successful Result");
+
+        private Result(TValue value, TError error, bool isSuccess)
+        {
+            _value = value;
+            _error = error;
+            _isSuccess = isSuccess;
+        }
+
+        /// <summary>
+        /// Creates a successful result with the specified value
+        /// </summary>
+        /// <param name="value">The success value</param>
+        /// <returns>A successful Result</returns>
+        public static Result<TValue, TError> Success(TValue value) =>
+            new(value, default, true);
+
+        /// <summary>
+        /// Creates a failed result with the specified error
+        /// </summary>
+        /// <param name="error">The error</param>
+        /// <returns>A failed Result</returns>
+        public static Result<TValue, TError> Failure(TError error) =>
+            new(default, error, false);
+
+        /// <summary>
+        /// Implicit conversion from value to successful Result
+        /// </summary>
+        public static implicit operator Result<TValue, TError>(TValue value) =>
+            Success(value);
+
+        /// <summary>
+        /// Attempts to get the success value
+        /// </summary>
+        /// <param name="value">The success value if successful</param>
+        /// <returns>True if successful, false otherwise</returns>
+#if !NETSTANDARD2_0
+        public bool TryGetValue([NotNullWhen(true)] out TValue value)
+#else
+        public bool TryGetValue(out TValue value)
+#endif
+        {
+            if (_isSuccess)
+            {
+                value = _value;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Attempts to get the error
+        /// </summary>
+        /// <param name="error">The error if failed</param>
+        /// <returns>True if failed, false otherwise</returns>
+#if !NETSTANDARD2_0
+        public bool TryGetError([NotNullWhen(true)] out TError error)
+#else
+        public bool TryGetError(out TError error)
+#endif
+        {
+            if (!_isSuccess)
+            {
+                error = _error;
+                return true;
+            }
+
+            error = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the value if successful, otherwise returns the specified default value
+        /// </summary>
+        /// <param name="defaultValue">Default value to return on failure</param>
+        /// <returns>The success value or default</returns>
+        public TValue GetValueOrDefault(TValue defaultValue = default) =>
+            _isSuccess ? _value : defaultValue;
+
+        /// <summary>
+        /// Gets the value if successful, otherwise returns the result of the factory function
+        /// </summary>
+        /// <param name="defaultFactory">Factory function to create default value</param>
+        /// <returns>The success value or factory result</returns>
+        public TValue GetValueOrDefault(Func<TValue> defaultFactory) =>
+            _isSuccess ? _value : defaultFactory();
+
+        /// <summary>
+        /// Gets the value if successful, otherwise returns the result of the error handler
+        /// </summary>
+        /// <param name="errorHandler">Handler that receives the error and returns a default value</param>
+        /// <returns>The success value or handler result</returns>
+        public TValue GetValueOrDefault(Func<TError, TValue> errorHandler) =>
+            _isSuccess ? _value : errorHandler(_error);
+
+        /// <summary>
+        /// Pattern matches on the result, executing the appropriate handler
+        /// </summary>
+        /// <typeparam name="TResult">Return type of handlers</typeparam>
+        /// <param name="onSuccess">Handler for success case</param>
+        /// <param name="onFailure">Handler for failure case</param>
+        /// <returns>Result of the executed handler</returns>
+        public TResult Match<TResult>(
+            Func<TValue, TResult> onSuccess,
+            Func<TError, TResult> onFailure) =>
+            _isSuccess ? onSuccess(_value) : onFailure(_error);
+
+        /// <summary>
+        /// Executes the appropriate action based on success or failure
+        /// </summary>
+        /// <param name="onSuccess">Action for success case</param>
+        /// <param name="onFailure">Action for failure case</param>
+        public void Switch(
+            Action<TValue> onSuccess,
+            Action<TError> onFailure)
+        {
+            if (_isSuccess)
+                onSuccess(_value);
+            else
+                onFailure(_error);
+        }
+
+        /// <summary>
+        /// Transforms the success value using the specified mapping function
+        /// </summary>
+        /// <typeparam name="TNew">Type of the new value</typeparam>
+        /// <param name="mapper">Function to transform the value</param>
+        /// <returns>A new Result with the transformed value or the original error</returns>
+        public Result<TNew, TError> Map<TNew>(Func<TValue, TNew> mapper) =>
+            _isSuccess
+                ? Result<TNew, TError>.Success(mapper(_value))
+                : Result<TNew, TError>.Failure(_error);
+
+        /// <summary>
+        /// Transforms the error using the specified mapping function
+        /// </summary>
+        /// <typeparam name="TNewError">Type of the new error</typeparam>
+        /// <param name="mapper">Function to transform the error</param>
+        /// <returns>A new Result with the original value or transformed error</returns>
+        public Result<TValue, TNewError> MapError<TNewError>(Func<TError, TNewError> mapper) =>
+            _isSuccess
+                ? Result<TValue, TNewError>.Success(_value)
+                : Result<TValue, TNewError>.Failure(mapper(_error));
+
+        /// <summary>
+        /// Chains another operation that returns a Result
+        /// </summary>
+        /// <typeparam name="TNew">Type of the new value</typeparam>
+        /// <param name="binder">Function that returns a new Result</param>
+        /// <returns>The new Result or the original error</returns>
+        public Result<TNew, TError> Bind<TNew>(Func<TValue, Result<TNew, TError>> binder) =>
+            _isSuccess ? binder(_value) : Result<TNew, TError>.Failure(_error);
+
+        /// <summary>
+        /// Executes an action on success, returning the original result
+        /// </summary>
+        /// <param name="action">Action to execute on success</param>
+        /// <returns>The original Result</returns>
+        public Result<TValue, TError> Tap(Action<TValue> action)
+        {
+            if (_isSuccess)
+                action(_value);
+            return this;
+        }
+
+        /// <summary>
+        /// Executes an action on failure, returning the original result
+        /// </summary>
+        /// <param name="action">Action to execute on failure</param>
+        /// <returns>The original Result</returns>
+        public Result<TValue, TError> TapError(Action<TError> action)
+        {
+            if (!_isSuccess)
+                action(_error);
+            return this;
+        }
+
+        /// <summary>
+        /// Ensures a condition is met, converting to failure if not
+        /// </summary>
+        /// <param name="predicate">Condition to check</param>
+        /// <param name="error">Error to use if condition fails</param>
+        /// <returns>The original Result or a failed Result</returns>
+        public Result<TValue, TError> Ensure(Func<TValue, bool> predicate, TError error) =>
+            _isSuccess && !predicate(_value)
+                ? Result<TValue, TError>.Failure(error)
+                : this;
+
+        /// <summary>
+        /// Converts this Result to use the built-in ResultError type
+        /// </summary>
+        /// <param name="errorMapper">Function to convert the error to ResultError</param>
+        /// <returns>A Result with ResultError</returns>
+        public Result<TValue> ToResult(Func<TError, ResultError> errorMapper) =>
+            _isSuccess
+                ? Result<TValue>.Success(_value)
+                : Result<TValue>.Failure(errorMapper(_error));
+
+        public bool Equals(Result<TValue, TError> other) =>
+            _isSuccess == other._isSuccess &&
+            Equals(_value, other._value) &&
+            Equals(_error, other._error);
+
+        public override bool Equals(object obj) =>
+            obj is Result<TValue, TError> other && Equals(other);
+
+        public override int GetHashCode()
+        {
+#if NETSTANDARD2_0
+            unchecked
+            {
+                var hashCode = _isSuccess.GetHashCode();
+                hashCode = (hashCode * 397) ^ (_value?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (_error?.GetHashCode() ?? 0);
+                return hashCode;
+            }
+#else
+            return HashCode.Combine(_isSuccess, _value, _error);
+#endif
+        }
+
+        public static bool operator ==(Result<TValue, TError> left, Result<TValue, TError> right) =>
+            left.Equals(right);
+
+        public static bool operator !=(Result<TValue, TError> left, Result<TValue, TError> right) =>
+            !left.Equals(right);
+
+        public override string ToString() =>
+            _isSuccess
+                ? $"Success({_value})"
+                : $"Failure({_error})";
+    }
+}

--- a/src/Cortex.Types/Result/ResultError.cs
+++ b/src/Cortex.Types/Result/ResultError.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cortex.Types
+{
+    /// <summary>
+    /// Represents an error in a Result operation with a message and optional exception
+    /// </summary>
+    public sealed class ResultError : IEquatable<ResultError>
+    {
+        /// <summary>
+        /// Gets the error message
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets the error code (optional)
+        /// </summary>
+        public string Code { get; }
+
+        /// <summary>
+        /// Gets the inner exception if one was the cause of the error
+        /// </summary>
+        public Exception Exception { get; }
+
+        /// <summary>
+        /// Gets additional metadata about the error
+        /// </summary>
+        public IReadOnlyDictionary<string, object> Metadata { get; }
+
+        /// <summary>
+        /// Creates a new ResultError with the specified message
+        /// </summary>
+        /// <param name="message">Error message</param>
+        public ResultError(string message)
+            : this(message, null, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new ResultError with the specified message and code
+        /// </summary>
+        /// <param name="message">Error message</param>
+        /// <param name="code">Error code</param>
+        public ResultError(string message, string code)
+            : this(message, code, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new ResultError with the specified message and exception
+        /// </summary>
+        /// <param name="message">Error message</param>
+        /// <param name="exception">Underlying exception</param>
+        public ResultError(string message, Exception exception)
+            : this(message, null, exception, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new ResultError with all properties
+        /// </summary>
+        /// <param name="message">Error message</param>
+        /// <param name="code">Error code</param>
+        /// <param name="exception">Underlying exception</param>
+        /// <param name="metadata">Additional metadata</param>
+        public ResultError(
+            string message,
+            string code,
+            Exception exception,
+            IDictionary<string, object> metadata)
+        {
+            Message = message ?? throw new ArgumentNullException(nameof(message));
+            Code = code;
+            Exception = exception;
+            Metadata = metadata != null
+                ? new Dictionary<string, object>(metadata)
+                : new Dictionary<string, object>();
+        }
+
+        /// <summary>
+        /// Creates a ResultError from an exception
+        /// </summary>
+        /// <param name="exception">The exception to convert</param>
+        /// <returns>A new ResultError</returns>
+        public static ResultError FromException(Exception exception)
+        {
+            if (exception == null)
+                throw new ArgumentNullException(nameof(exception));
+
+            return new ResultError(
+                exception.Message,
+                exception.GetType().Name,
+                exception,
+                null);
+        }
+
+        /// <summary>
+        /// Creates a composite error from multiple errors
+        /// </summary>
+        /// <param name="errors">Collection of errors</param>
+        /// <returns>A new ResultError representing all errors</returns>
+        public static ResultError Aggregate(IEnumerable<ResultError> errors)
+        {
+            if (errors == null)
+                throw new ArgumentNullException(nameof(errors));
+
+            var errorList = errors.ToList();
+            if (errorList.Count == 0)
+                throw new ArgumentException("At least one error is required", nameof(errors));
+
+            if (errorList.Count == 1)
+                return errorList[0];
+
+            var messages = string.Join("; ", errorList.Select(e => e.Message));
+            var metadata = new Dictionary<string, object>
+            {
+                ["InnerErrors"] = errorList
+            };
+
+            return new ResultError(
+                $"Multiple errors occurred: {messages}",
+                "AGGREGATE_ERROR",
+                null,
+                metadata);
+        }
+
+        public bool Equals(ResultError other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Message == other.Message && Code == other.Code;
+        }
+
+        public override bool Equals(object obj) =>
+            obj is ResultError other && Equals(other);
+
+        public override int GetHashCode()
+        {
+#if NETSTANDARD2_0
+            unchecked
+            {
+                return ((Message?.GetHashCode() ?? 0) * 397) ^ (Code?.GetHashCode() ?? 0);
+            }
+#else
+            return HashCode.Combine(Message, Code);
+#endif
+        }
+
+        public static bool operator ==(ResultError left, ResultError right) =>
+            Equals(left, right);
+
+        public static bool operator !=(ResultError left, ResultError right) =>
+            !Equals(left, right);
+
+        public override string ToString() =>
+            string.IsNullOrEmpty(Code)
+                ? Message
+                : $"[{Code}] {Message}";
+    }
+}

--- a/src/Cortex.Types/Result/ResultExtensions.cs
+++ b/src/Cortex.Types/Result/ResultExtensions.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Cortex.Types
+{
+    /// <summary>
+    /// Provides static factory methods and utilities for creating Result instances
+    /// </summary>
+    public static class Result
+    {
+        /// <summary>
+        /// Creates a successful result with the specified value
+        /// </summary>
+        /// <typeparam name="T">Type of the value</typeparam>
+        /// <param name="value">The success value</param>
+        /// <returns>A successful Result</returns>
+        public static Result<T> Success<T>(T value) =>
+            Result<T>.Success(value);
+
+        /// <summary>
+        /// Creates a successful result with the specified value and custom error type
+        /// </summary>
+        /// <typeparam name="TValue">Type of the value</typeparam>
+        /// <typeparam name="TError">Type of the error</typeparam>
+        /// <param name="value">The success value</param>
+        /// <returns>A successful Result</returns>
+        public static Result<TValue, TError> Success<TValue, TError>(TValue value) =>
+            Result<TValue, TError>.Success(value);
+
+        /// <summary>
+        /// Creates a failed result with the specified error
+        /// </summary>
+        /// <typeparam name="T">Type of the value</typeparam>
+        /// <param name="error">The error</param>
+        /// <returns>A failed Result</returns>
+        public static Result<T> Failure<T>(ResultError error) =>
+            Result<T>.Failure(error);
+
+        /// <summary>
+        /// Creates a failed result with the specified error message
+        /// </summary>
+        /// <typeparam name="T">Type of the value</typeparam>
+        /// <param name="errorMessage">The error message</param>
+        /// <returns>A failed Result</returns>
+        public static Result<T> Failure<T>(string errorMessage) =>
+            Result<T>.Failure(errorMessage);
+
+        /// <summary>
+        /// Creates a failed result from an exception
+        /// </summary>
+        /// <typeparam name="T">Type of the value</typeparam>
+        /// <param name="exception">The exception</param>
+        /// <returns>A failed Result</returns>
+        public static Result<T> Failure<T>(Exception exception) =>
+            Result<T>.Failure(exception);
+
+        /// <summary>
+        /// Creates a failed result with the specified error and custom error type
+        /// </summary>
+        /// <typeparam name="TValue">Type of the value</typeparam>
+        /// <typeparam name="TError">Type of the error</typeparam>
+        /// <param name="error">The error</param>
+        /// <returns>A failed Result</returns>
+        public static Result<TValue, TError> Failure<TValue, TError>(TError error) =>
+            Result<TValue, TError>.Failure(error);
+
+        /// <summary>
+        /// Executes the specified function and wraps any exception in a failed Result
+        /// </summary>
+        /// <typeparam name="T">Type of the return value</typeparam>
+        /// <param name="func">Function to execute</param>
+        /// <returns>A Result containing the function result or the caught exception</returns>
+        public static Result<T> Try<T>(Func<T> func)
+        {
+            try
+            {
+                return Result<T>.Success(func());
+            }
+            catch (Exception ex)
+            {
+                return Result<T>.Failure(ex);
+            }
+        }
+
+        /// <summary>
+        /// Executes the specified function and wraps any exception in a failed Result
+        /// </summary>
+        /// <typeparam name="T">Type of the return value</typeparam>
+        /// <param name="func">Function to execute</param>
+        /// <param name="exceptionHandler">Handler to convert exception to error</param>
+        /// <returns>A Result containing the function result or the handled exception</returns>
+        public static Result<T> Try<T>(Func<T> func, Func<Exception, ResultError> exceptionHandler)
+        {
+            try
+            {
+                return Result<T>.Success(func());
+            }
+            catch (Exception ex)
+            {
+                return Result<T>.Failure(exceptionHandler(ex));
+            }
+        }
+
+        /// <summary>
+        /// Executes the specified async function and wraps any exception in a failed Result
+        /// </summary>
+        /// <typeparam name="T">Type of the return value</typeparam>
+        /// <param name="func">Async function to execute</param>
+        /// <returns>A Task containing a Result with the function result or the caught exception</returns>
+        public static async Task<Result<T>> TryAsync<T>(Func<Task<T>> func)
+        {
+            try
+            {
+                return Result<T>.Success(await func().ConfigureAwait(false));
+            }
+            catch (Exception ex)
+            {
+                return Result<T>.Failure(ex);
+            }
+        }
+
+        /// <summary>
+        /// Combines two results, returning failure if either fails
+        /// </summary>
+        public static Result<(T1, T2)> Combine<T1, T2>(
+            Result<T1> result1,
+            Result<T2> result2)
+        {
+            if (result1.IsFailure)
+                return Result<(T1, T2)>.Failure(result1.Error);
+            if (result2.IsFailure)
+                return Result<(T1, T2)>.Failure(result2.Error);
+
+            return Result<(T1, T2)>.Success((result1.Value, result2.Value));
+        }
+
+        /// <summary>
+        /// Combines three results, returning failure if any fails
+        /// </summary>
+        public static Result<(T1, T2, T3)> Combine<T1, T2, T3>(
+            Result<T1> result1,
+            Result<T2> result2,
+            Result<T3> result3)
+        {
+            if (result1.IsFailure)
+                return Result<(T1, T2, T3)>.Failure(result1.Error);
+            if (result2.IsFailure)
+                return Result<(T1, T2, T3)>.Failure(result2.Error);
+            if (result3.IsFailure)
+                return Result<(T1, T2, T3)>.Failure(result3.Error);
+
+            return Result<(T1, T2, T3)>.Success((result1.Value, result2.Value, result3.Value));
+        }
+
+        /// <summary>
+        /// Creates a Result based on a condition
+        /// </summary>
+        /// <typeparam name="T">Type of the value</typeparam>
+        /// <param name="condition">Condition to evaluate</param>
+        /// <param name="value">Value to use if condition is true</param>
+        /// <param name="error">Error to use if condition is false</param>
+        /// <returns>Success or Failure Result based on condition</returns>
+        public static Result<T> SuccessIf<T>(bool condition, T value, ResultError error) =>
+            condition ? Result<T>.Success(value) : Result<T>.Failure(error);
+
+        /// <summary>
+        /// Creates a Result based on a condition
+        /// </summary>
+        /// <typeparam name="T">Type of the value</typeparam>
+        /// <param name="condition">Condition to evaluate</param>
+        /// <param name="value">Value to use if condition is true</param>
+        /// <param name="errorMessage">Error message to use if condition is false</param>
+        /// <returns>Success or Failure Result based on condition</returns>
+        public static Result<T> SuccessIf<T>(bool condition, T value, string errorMessage) =>
+            condition ? Result<T>.Success(value) : Result<T>.Failure(errorMessage);
+
+        /// <summary>
+        /// Creates a Result based on a condition (inverted)
+        /// </summary>
+        /// <typeparam name="T">Type of the value</typeparam>
+        /// <param name="condition">Condition to evaluate</param>
+        /// <param name="value">Value to use if condition is false</param>
+        /// <param name="error">Error to use if condition is true</param>
+        /// <returns>Success or Failure Result based on condition</returns>
+        public static Result<T> FailureIf<T>(bool condition, T value, ResultError error) =>
+            condition ? Result<T>.Failure(error) : Result<T>.Success(value);
+
+        /// <summary>
+        /// Creates a Result based on a condition (inverted)
+        /// </summary>
+        /// <typeparam name="T">Type of the value</typeparam>
+        /// <param name="condition">Condition to evaluate</param>
+        /// <param name="value">Value to use if condition is false</param>
+        /// <param name="errorMessage">Error message to use if condition is true</param>
+        /// <returns>Success or Failure Result based on condition</returns>
+        public static Result<T> FailureIf<T>(bool condition, T value, string errorMessage) =>
+            condition ? Result<T>.Failure(errorMessage) : Result<T>.Success(value);
+    }
+}


### PR DESCRIPTION
- Introduce OneOf<T1..T8> and AnyOf<T1..T8> discriminated unions
- Add Result<T>, Result<TValue, TError>, and ResultError types
- Provide IResult interfaces and static Result factory/utilities
- Implement full unit test coverage for all new types
- Fix bug in OneOf3/OneOf4 Equals(object) generic arity
- Add Cortex.Types project reference to test project

#172 