### PR TITLE
Optimize operator allocations and Mediator pipeline

### DIFF
--- a/src/Cortex.Mediator/Mediator.cs
+++ b/src/Cortex.Mediator/Mediator.cs
@@ -4,6 +4,7 @@ using Cortex.Mediator.Queries;
 using Cortex.Mediator.Streaming;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -142,25 +143,36 @@ namespace Cortex.Mediator
             CancellationToken cancellationToken = default)
             where TNotification : INotification
         {
-            var handlers = _serviceProvider.GetServices<INotificationHandler<TNotification>>().ToList();
-            var behaviors = _serviceProvider.GetServices<INotificationPipelineBehavior<TNotification>>().Reverse().ToList();
+            var handlers = _serviceProvider.GetServices<INotificationHandler<TNotification>>();
+            var behaviors = _serviceProvider.GetServices<INotificationPipelineBehavior<TNotification>>();
 
-            // Execute all handlers, each wrapped by the pipeline behaviors
-            var tasks = handlers.Select(handler =>
+            // Materialize behaviors once since we need to iterate multiple times
+            // Use stackalloc-friendly pattern for small counts
+            var behaviorList = behaviors as INotificationPipelineBehavior<TNotification>[] ?? behaviors.ToArray();
+            Array.Reverse(behaviorList);
+
+            // Count handlers to pre-allocate task array
+            var handlerList = handlers as INotificationHandler<TNotification>[] ?? handlers.ToArray();
+            if (handlerList.Length == 0)
+                return;
+
+            var tasks = new Task[handlerList.Length];
+            for (int i = 0; i < handlerList.Length; i++)
             {
+                var handler = handlerList[i];
                 // Build the pipeline for this specific handler
                 NotificationHandlerDelegate handlerDelegate = () => handler.Handle(notification, cancellationToken);
 
-                // Wrap the handler with all behaviors (in reverse order so first registered executes first)
-                foreach (var behavior in behaviors)
+                // Wrap the handler with all behaviors (already reversed)
+                foreach (var behavior in behaviorList)
                 {
                     var currentDelegate = handlerDelegate;
                     var currentBehavior = behavior;
                     handlerDelegate = () => currentBehavior.Handle(notification, currentDelegate, cancellationToken);
                 }
 
-                return handlerDelegate();
-            });
+                tasks[i] = handlerDelegate();
+            }
 
             await Task.WhenAll(tasks);
         }
@@ -174,15 +186,17 @@ namespace Cortex.Mediator
                 throw new ArgumentNullException(nameof(query));
 
             var handler = _serviceProvider.GetRequiredService<IStreamQueryHandler<TQuery, TResult>>();
-            var behaviors = _serviceProvider.GetServices<IStreamQueryPipelineBehavior<TQuery, TResult>>().Reverse().ToList();
+            var behaviors = _serviceProvider.GetServices<IStreamQueryPipelineBehavior<TQuery, TResult>>();
 
             // Build the pipeline
             StreamQueryHandlerDelegate<TResult> handlerDelegate = () => handler.Handle(query, cancellationToken);
 
-            foreach (var behavior in behaviors)
+            // Materialize and reverse behaviors
+            var behaviorArray = behaviors as IStreamQueryPipelineBehavior<TQuery, TResult>[] ?? behaviors.ToArray();
+            for (int i = behaviorArray.Length - 1; i >= 0; i--)
             {
                 var currentDelegate = handlerDelegate;
-                var currentBehavior = behavior;
+                var currentBehavior = behaviorArray[i];
                 handlerDelegate = () => currentBehavior.Handle(query, currentDelegate, cancellationToken);
             }
 

--- a/src/Cortex.Streams/Operators/AggregateOperator.cs
+++ b/src/Cortex.Streams/Operators/AggregateOperator.cs
@@ -16,6 +16,10 @@ namespace Cortex.Streams.Operators
         private readonly IDataStore<TKey, TAggregate> _stateStore;
         private IOperator _nextOperator;
 
+        // Cached operator name to avoid string allocation on hot path
+        private static readonly string OperatorName = $"AggregateOperator<{typeof(TKey).Name},{typeof(TCurrent).Name},{typeof(TAggregate).Name}>";
+        private static readonly string CurrentTypeName = typeof(TCurrent).Name;
+
         private StreamExecutionOptions _executionOptions = StreamExecutionOptions.Default;
 
         // Telemetry fields
@@ -82,11 +86,8 @@ namespace Cortex.Streams.Operators
             catch (InvalidCastException)
             {
                 throw new ArgumentException(
-                    $"Expected input of type {typeof(TCurrent).Name}, but received {input?.GetType().Name ?? "null"}");
+                    $"Expected input of type {CurrentTypeName}, but received {input?.GetType().Name ?? "null"}");
             }
-
-            var operatorName =
-                $"AggregateOperator<{typeof(TKey).Name},{typeof(TCurrent).Name},{typeof(TAggregate).Name}>";
 
             bool executedSuccessfully;
             KeyValuePair<TKey, TAggregate> result = default;
@@ -101,7 +102,7 @@ namespace Cortex.Streams.Operators
                     {
                         executedSuccessfully = ErrorHandlingHelper.TryExecute<TCurrent, KeyValuePair<TKey, TAggregate>>(
                             _executionOptions,
-                            operatorName,
+                            OperatorName,
                             input,
                             current =>
                             {
@@ -145,7 +146,7 @@ namespace Cortex.Streams.Operators
             {
                 executedSuccessfully = ErrorHandlingHelper.TryExecute<TCurrent, KeyValuePair<TKey, TAggregate>>(
                     _executionOptions,
-                    operatorName,
+                    OperatorName,
                     input,
                     current =>
                     {

--- a/src/Cortex.Streams/Operators/BranchOperator.cs
+++ b/src/Cortex.Streams/Operators/BranchOperator.cs
@@ -10,6 +10,9 @@ namespace Cortex.Streams.Operators
         private readonly string _branchName;
         private readonly IOperator _branchOperator;
 
+        // Cached span name to avoid string allocation on hot path
+        private readonly string _spanName;
+
         // Telemetry fields
         private ITelemetryProvider _telemetryProvider;
         private ICounter _processedCounter;
@@ -22,6 +25,7 @@ namespace Cortex.Streams.Operators
         {
             _branchName = branchName ?? throw new ArgumentNullException(nameof(branchName));
             _branchOperator = branchOperator ?? throw new ArgumentNullException(nameof(branchOperator));
+            _spanName = $"BranchOperator.Process.{branchName}";
         }
 
         public string BranchName => _branchName;
@@ -60,7 +64,7 @@ namespace Cortex.Streams.Operators
             {
                 var stopwatch = Stopwatch.StartNew();
 
-                using (var span = _tracer.StartSpan($"BranchOperator.Process.{_branchName}"))
+                using (var span = _tracer.StartSpan(_spanName))
                 {
                     try
                     {

--- a/src/Cortex.Streams/Operators/FilterOperator.cs
+++ b/src/Cortex.Streams/Operators/FilterOperator.cs
@@ -15,6 +15,10 @@ namespace Cortex.Streams.Operators
         private readonly Func<T, bool> _predicate;
         private IOperator _nextOperator;
 
+        // Cached operator name to avoid string allocation on hot path
+        private static readonly string OperatorName = $"FilterOperator<{typeof(T).Name}>";
+        private static readonly string TypeName = typeof(T).Name;
+
         // Telemetry fields
         private ITelemetryProvider _telemetryProvider;
         private ICounter _processedCounter;
@@ -79,9 +83,7 @@ namespace Cortex.Streams.Operators
         public void Process(object input)
         {
             if (!(input is T typedInput))
-                throw new ArgumentException($"Expected input of type {typeof(T).Name}, but received {input?.GetType().Name ?? "null"}");
-
-            var operatorName = $"FilterOperator<{typeof(T).Name}>";
+                throw new ArgumentException($"Expected input of type {TypeName}, but received {input?.GetType().Name ?? "null"}");
 
             bool isPassed = false;
             bool executedSuccessfully;
@@ -95,7 +97,7 @@ namespace Cortex.Streams.Operators
                     {
                         executedSuccessfully = ErrorHandlingHelper.TryExecute<T, bool>(
                             _executionOptions,
-                            operatorName,
+                            OperatorName,
                             input,
                             _predicate,
                             typedInput,
@@ -122,7 +124,7 @@ namespace Cortex.Streams.Operators
             {
                 executedSuccessfully = ErrorHandlingHelper.TryExecute<T, bool>(
                     _executionOptions,
-                    operatorName,
+                    OperatorName,
                     input,
                     _predicate,
                     typedInput,

--- a/src/Cortex.Streams/Operators/FlatMapOperator.cs
+++ b/src/Cortex.Streams/Operators/FlatMapOperator.cs
@@ -21,6 +21,10 @@ namespace Cortex.Streams.Operators
         private readonly Func<TInput, IEnumerable<TOutput>> _flatMapFunction;
         private IOperator _nextOperator;
 
+        // Cached operator name to avoid string allocation on hot path
+        private static readonly string OperatorName = $"FlatMapOperator<{typeof(TInput).Name},{typeof(TOutput).Name}>";
+        private static readonly string InputTypeName = typeof(TInput).Name;
+
         // Telemetry fields
         private ITelemetryProvider _telemetryProvider;
         private ICounter _processedCounter;
@@ -109,12 +113,8 @@ namespace Cortex.Streams.Operators
             catch (InvalidCastException)
             {
                 throw new ArgumentException(
-                    $"Expected input of type {typeof(TInput).Name}, but received {input?.GetType().Name ?? "null"}");
+                    $"Expected input of type {InputTypeName}, but received {input?.GetType().Name ?? "null"}");
             }
-
-
-            var operatorName =
-                $"FlatMapOperator<{typeof(TInput).Name},{typeof(TOutput).Name}>";
 
             bool executedSuccessfully;
             IEnumerable<TOutput> outputs = Array.Empty<TOutput>();
@@ -128,7 +128,7 @@ namespace Cortex.Streams.Operators
                     {
                         executedSuccessfully = ErrorHandlingHelper.TryExecute<TInput, IEnumerable<TOutput>>(
                             _executionOptions,
-                            operatorName,
+                            OperatorName,
                             input,
                             current => _flatMapFunction(current) ?? Array.Empty<TOutput>(),
                             typedInput,
@@ -155,7 +155,7 @@ namespace Cortex.Streams.Operators
             {
                 executedSuccessfully = ErrorHandlingHelper.TryExecute<TInput, IEnumerable<TOutput>>(
                     _executionOptions,
-                    operatorName,
+                    OperatorName,
                     input,
                     current => _flatMapFunction(current) ?? Array.Empty<TOutput>(),
                     typedInput,

--- a/src/Cortex.Streams/Operators/GroupByKeyOperator.cs
+++ b/src/Cortex.Streams/Operators/GroupByKeyOperator.cs
@@ -14,6 +14,10 @@ namespace Cortex.Streams.Operators
         private readonly IDataStore<TKey, List<TInput>> _stateStore;
         private IOperator _nextOperator;
 
+        // Cached operator name to avoid string allocation on hot path
+        private static readonly string OperatorName = $"GroupByKeyOperator<{typeof(TInput).Name},{typeof(TKey).Name}>";
+        private static readonly string InputTypeName = typeof(TInput).Name;
+
         private StreamExecutionOptions _executionOptions = StreamExecutionOptions.Default;
 
         // Telemetry fields
@@ -81,11 +85,8 @@ namespace Cortex.Streams.Operators
             catch (InvalidCastException)
             {
                 throw new ArgumentException(
-                    $"Expected input of type {typeof(TInput).Name}, but received {input?.GetType().Name ?? "null"}");
+                    $"Expected input of type {InputTypeName}, but received {input?.GetType().Name ?? "null"}");
             }
-
-            var operatorName =
-                $"GroupByKeyOperator<{typeof(TInput).Name},{typeof(TKey).Name}>";
 
             bool executedSuccessfully;
             TKey key = default;
@@ -103,7 +104,7 @@ namespace Cortex.Streams.Operators
                         executedSuccessfully =
                             ErrorHandlingHelper.TryExecute<TInput, KeyValuePair<TKey, List<TInput>>>(
                                 _executionOptions,
-                                operatorName,
+                                OperatorName,
                                 input,
                                 current =>
                                 {
@@ -148,7 +149,7 @@ namespace Cortex.Streams.Operators
                 executedSuccessfully =
                     ErrorHandlingHelper.TryExecute<TInput, KeyValuePair<TKey, List<TInput>>>(
                         _executionOptions,
-                        operatorName,
+                        OperatorName,
                         input,
                         current =>
                         {

--- a/src/Cortex.Streams/Operators/MapOperator.cs
+++ b/src/Cortex.Streams/Operators/MapOperator.cs
@@ -16,6 +16,10 @@ namespace Cortex.Streams.Operators
         private readonly Func<TInput, TOutput> _mapFunction;
         private IOperator _nextOperator;
 
+        // Cached operator name to avoid string allocation on hot path
+        private static readonly string OperatorName = $"MapOperator<{typeof(TInput).Name},{typeof(TOutput).Name}>";
+        private static readonly string InputTypeName = typeof(TInput).Name;
+
         // Telemetry fields
         private ITelemetryProvider _telemetryProvider;
         private ICounter _processedCounter;
@@ -62,9 +66,8 @@ namespace Cortex.Streams.Operators
         public void Process(object input)
         {
             if (!(input is TInput typedInput))
-                throw new ArgumentException($"Expected input of type {typeof(TInput).Name}, but received {input?.GetType().Name ?? "null"}");
+                throw new ArgumentException($"Expected input of type {InputTypeName}, but received {input?.GetType().Name ?? "null"}");
 
-            var operatorName = $"MapOperator<{typeof(TInput).Name},{typeof(TOutput).Name}>";
             TOutput output;
             bool shouldContinue;
 
@@ -77,7 +80,7 @@ namespace Cortex.Streams.Operators
                     {
                         shouldContinue = ErrorHandlingHelper.TryExecute<TInput, TOutput>(
                             _executionOptions,
-                            operatorName,
+                            OperatorName,
                             input,
                             _mapFunction,
                             typedInput,
@@ -103,7 +106,7 @@ namespace Cortex.Streams.Operators
             {
                 shouldContinue = ErrorHandlingHelper.TryExecute<TInput, TOutput>(
                     _executionOptions,
-                    operatorName,
+                    OperatorName,
                     input,
                     _mapFunction,
                     typedInput,

--- a/src/Cortex.Streams/Operators/SinkOperator.cs
+++ b/src/Cortex.Streams/Operators/SinkOperator.cs
@@ -14,6 +14,9 @@ namespace Cortex.Streams.Operators
     {
         private readonly Action<TInput> _sinkFunction;
 
+        // Cached operator name to avoid string allocation on hot path
+        private static readonly string OperatorName = $"SinkOperator<{typeof(TInput).Name}>";
+
         // Telemetry fields
         private ITelemetryProvider _telemetryProvider;
         private ICounter _processedCounter;
@@ -61,8 +64,6 @@ namespace Cortex.Streams.Operators
         {
             TInput typedInput = (TInput)input;
 
-            var operatorName = $"SinkOperator<{typeof(TInput).Name}>";
-
             if (_telemetryProvider != null)
             {
                 var stopwatch = Stopwatch.StartNew();
@@ -72,7 +73,7 @@ namespace Cortex.Streams.Operators
                     {
                         var executed = ErrorHandlingHelper.TryExecute<TInput>(
                             _executionOptions,
-                            operatorName,
+                            OperatorName,
                             input,
                             _sinkFunction);
 
@@ -96,7 +97,7 @@ namespace Cortex.Streams.Operators
             {
                 ErrorHandlingHelper.TryExecute<TInput>(
                     _executionOptions,
-                    operatorName,
+                    OperatorName,
                     input,
                     _sinkFunction);
             }


### PR DESCRIPTION
Refactor stream operators to cache operator/type names, reducing string allocations and improving error message consistency. Optimize Mediator's PublishAsync and CreateStream by materializing handler/behavior arrays only once and pre-allocating task arrays. Cache span names in BranchOperator for telemetry. Remove redundant variables and streamline code for better performance and clarity.