### PR TITLE
Simplify StreamBuilder API to use a single type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ Cortex Data Framework makes it easy to set up and run real-time data processing 
 ### 1. Creating a Stream
 
 ```csharp
-var stream = StreamBuilder<int, int>.CreateNewStream("ExampleStream")
+var stream = StreamBuilder<int>.CreateNewStream("ExampleStream")
+    .Stream()
     .Map(x => x * 2)
     .Filter(x => x > 10)
     .Sink(Console.WriteLine)
@@ -203,9 +204,10 @@ Console.WriteLine(stateStore.Get("key1"));
 
 ```csharp
 var telemetryProvider = new OpenTelemetryProvider();
-var stream = StreamBuilder<int, int>
+var stream = StreamBuilder<int>
     .CreateNewStream("TelemetryStream")
     .WithTelemetry(telemetryProvider)
+    .Stream()
     .Map(x => x * 2)
     .Sink(Console.WriteLine)
     .Build();
@@ -239,7 +241,7 @@ public class ClickEvent
         static void Main(string[] args)
         {
             // Build the stream
-            var stream = StreamBuilder<ClickEvent, ClickEvent>.CreateNewStream("ClickStream")
+            var stream = StreamBuilder<ClickEvent>.CreateNewStream("ClickStream")
                 .Stream()
                 .Filter(e => !string.IsNullOrEmpty(e.PageUrl))
                 .GroupBySilently(

--- a/src/Cortex.Streams.Mediator/Extensions/InitialStreamBuilderMediatorExtensions.cs
+++ b/src/Cortex.Streams.Mediator/Extensions/InitialStreamBuilderMediatorExtensions.cs
@@ -15,21 +15,20 @@ namespace Cortex.Streams.Mediator.Extensions
         /// Starts a stream using a Mediator streaming query as the source.
         /// </summary>
         /// <typeparam name="TIn">The initial input type of the stream.</typeparam>
-        /// <typeparam name="TCurrent">The current type of data in the stream (same as TIn for initial builders).</typeparam>
         /// <typeparam name="TQuery">The type of streaming query.</typeparam>
         /// <param name="builder">The initial stream builder instance.</param>
         /// <param name="mediator">The mediator instance.</param>
         /// <param name="query">The streaming query to execute.</param>
         /// <param name="errorHandler">Optional handler for errors during query execution.</param>
         /// <returns>A stream builder for further configuration.</returns>
-        public static IStreamBuilder<TIn, TCurrent> StreamFromQuery<TIn, TCurrent, TQuery>(
-            this IInitialStreamBuilder<TIn, TCurrent> builder,
+        public static IStreamBuilder<TIn, TIn> StreamFromQuery<TIn, TQuery>(
+            this IInitialStreamBuilder<TIn> builder,
             IMediator mediator,
             TQuery query,
             Action<Exception> errorHandler = null)
-            where TQuery : IStreamQuery<TCurrent>
+            where TQuery : IStreamQuery<TIn>
         {
-            var sourceOperator = new MediatorStreamQuerySourceOperator<TQuery, TCurrent>(
+            var sourceOperator = new MediatorStreamQuerySourceOperator<TQuery, TIn>(
                 mediator,
                 query,
                 errorHandler);
@@ -42,21 +41,20 @@ namespace Cortex.Streams.Mediator.Extensions
         /// This is useful when the query needs to be created lazily or with current context.
         /// </summary>
         /// <typeparam name="TIn">The initial input type of the stream.</typeparam>
-        /// <typeparam name="TCurrent">The current type of data in the stream.</typeparam>
         /// <typeparam name="TQuery">The type of streaming query.</typeparam>
         /// <param name="builder">The initial stream builder instance.</param>
         /// <param name="mediator">The mediator instance.</param>
         /// <param name="queryFactory">A factory function to create the streaming query.</param>
         /// <param name="errorHandler">Optional handler for errors during query execution.</param>
         /// <returns>A stream builder for further configuration.</returns>
-        public static IStreamBuilder<TIn, TCurrent> StreamFromQueryFactory<TIn, TCurrent, TQuery>(
-            this IInitialStreamBuilder<TIn, TCurrent> builder,
+        public static IStreamBuilder<TIn, TIn> StreamFromQueryFactory<TIn, TQuery>(
+            this IInitialStreamBuilder<TIn> builder,
             IMediator mediator,
             Func<TQuery> queryFactory,
             Action<Exception> errorHandler = null)
-            where TQuery : IStreamQuery<TCurrent>
+            where TQuery : IStreamQuery<TIn>
         {
-            var sourceOperator = new MediatorStreamQueryFactorySourceOperator<TQuery, TCurrent>(
+            var sourceOperator = new MediatorStreamQueryFactorySourceOperator<TQuery, TIn>(
                 mediator,
                 queryFactory,
                 errorHandler);

--- a/src/Cortex.Streams/Abstractions/IInitialStreamBuilder.cs
+++ b/src/Cortex.Streams/Abstractions/IInitialStreamBuilder.cs
@@ -5,14 +5,18 @@ using System;
 
 namespace Cortex.Streams.Abstractions
 {
-    public interface IInitialStreamBuilder<TIn, TCurrent>
+    /// <summary>
+    /// Initial builder interface for creating a stream processing pipeline.
+    /// </summary>
+    /// <typeparam name="TIn">The type of the initial input to the stream.</typeparam>
+    public interface IInitialStreamBuilder<TIn>
     {
         /// <summary>
         /// Start the stream inside the application, in-app streaming
         /// </summary>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        IStreamBuilder<TIn, TCurrent> Stream();
+        IStreamBuilder<TIn, TIn> Stream();
 
         /// <summary>
         /// Start configuring the Stream
@@ -20,7 +24,7 @@ namespace Cortex.Streams.Abstractions
         /// <param name="sourceOperator">Type of the Source Operator</param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        IStreamBuilder<TIn, TCurrent> Stream(ISourceOperator<TCurrent> sourceOperator);
+        IStreamBuilder<TIn, TIn> Stream(ISourceOperator<TIn> sourceOperator);
 
         /// <summary>
         /// Configure Telemetry for the Stream
@@ -28,7 +32,7 @@ namespace Cortex.Streams.Abstractions
         /// <param name="telemetryProvider">Telemetry provider like OpenTelemetryProvider</param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        IInitialStreamBuilder<TIn, TCurrent> WithTelemetry(ITelemetryProvider telemetryProvider);
+        IInitialStreamBuilder<TIn> WithTelemetry(ITelemetryProvider telemetryProvider);
 
 
         /// <summary>
@@ -36,7 +40,7 @@ namespace Cortex.Streams.Abstractions
         /// </summary>
         /// <param name="executionOptions">Execution options controlling error handling strategy and callbacks.</param>
         /// <returns>The initial builder for chaining.</returns>
-        IInitialStreamBuilder<TIn, TCurrent> WithErrorHandling(StreamExecutionOptions executionOptions);
+        IInitialStreamBuilder<TIn> WithErrorHandling(StreamExecutionOptions executionOptions);
 
     }
 }

--- a/src/Cortex.Streams/StreamBuilder.cs
+++ b/src/Cortex.Streams/StreamBuilder.cs
@@ -10,11 +10,28 @@ using System.Collections.Generic;
 namespace Cortex.Streams
 {
     /// <summary>
+    /// Entry point for creating a stream processing pipeline.
+    /// </summary>
+    /// <typeparam name="TIn">The type of the initial input to the stream.</typeparam>
+    public static class StreamBuilder<TIn>
+    {
+        /// <summary>
+        /// Creates a new stream with the specified name.
+        /// </summary>
+        /// <param name="name">The name of the stream.</param>
+        /// <returns>An initial stream builder.</returns>
+        public static IInitialStreamBuilder<TIn> CreateNewStream(string name)
+        {
+            return new StreamBuilder<TIn, TIn>(name);
+        }
+    }
+
+    /// <summary>
     /// Builds a stream processing pipeline with optional branches.
     /// </summary>
     /// <typeparam name="TIn">The type of the initial input to the stream.</typeparam>
     /// <typeparam name="TCurrent">The current type of data in the stream.</typeparam>
-    public class StreamBuilder<TIn, TCurrent> : IInitialStreamBuilder<TIn, TCurrent>, IStreamBuilder<TIn, TCurrent>
+    internal class StreamBuilder<TIn, TCurrent> : IInitialStreamBuilder<TIn>, IStreamBuilder<TIn, TCurrent>
     {
         private readonly string _name;
         private IOperator _firstOperator;
@@ -29,12 +46,12 @@ namespace Cortex.Streams
 
 
 
-        private StreamBuilder(string name)
+        internal StreamBuilder(string name)
         {
             _name = name;
         }
 
-        private StreamBuilder(string name, IOperator firstOperator, IOperator lastOperator, bool sourceAdded, ITelemetryProvider telemetryProvider = null, StreamExecutionOptions executionOptions = null)
+        internal StreamBuilder(string name, IOperator firstOperator, IOperator lastOperator, bool sourceAdded, ITelemetryProvider telemetryProvider = null, StreamExecutionOptions executionOptions = null)
         {
             _name = name;
             _firstOperator = firstOperator;
@@ -48,20 +65,10 @@ namespace Cortex.Streams
         /// Creates a new stream with the specified name.
         /// </summary>
         /// <param name="name">The name of the stream.</param>
-        /// <returns>An initial stream builder.</returns>
-        public static IInitialStreamBuilder<TIn, TIn> CreateNewStream(string name)
-        {
-            return new StreamBuilder<TIn, TIn>(name);
-        }
-
-        /// <summary>
-        /// Creates a new stream with the specified name.
-        /// </summary>
-        /// <param name="name">The name of the stream.</param>
         /// <param name="firstOperator">The first operator in the pipeline</param>
         /// <param name="lastOperator">The last operator in the pipeline</param>
         /// <returns>An initial stream builder.</returns>
-        public static IStreamBuilder<TIn, TCurrent> CreateNewStream(string name, IOperator firstOperator, IOperator lastOperator)
+        internal static IStreamBuilder<TIn, TCurrent> CreateNewStream(string name, IOperator firstOperator, IOperator lastOperator)
         {
             return new StreamBuilder<TIn, TCurrent>(name, firstOperator, lastOperator, false, null);
         }
@@ -163,14 +170,14 @@ namespace Cortex.Streams
         /// <param name="sourceOperator">Type of the Source Operator</param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        public IStreamBuilder<TIn, TCurrent> Stream(ISourceOperator<TCurrent> sourceOperator)
+        IStreamBuilder<TIn, TIn> IInitialStreamBuilder<TIn>.Stream(ISourceOperator<TIn> sourceOperator)
         {
             if (_sourceAdded)
             {
                 throw new InvalidOperationException("Source operator already added.");
             }
 
-            var sourceAdapter = new SourceOperatorAdapter<TCurrent>(sourceOperator);
+            var sourceAdapter = new SourceOperatorAdapter<TIn>(sourceOperator);
 
             if (_firstOperator == null)
             {
@@ -183,7 +190,7 @@ namespace Cortex.Streams
             }
 
             _sourceAdded = true;
-            return this; // Returns IStreamBuilder<TIn, TCurrent>
+            return (IStreamBuilder<TIn, TIn>)(object)this;
         }
 
         /// <summary>
@@ -191,7 +198,7 @@ namespace Cortex.Streams
         /// </summary>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        public IStreamBuilder<TIn, TCurrent> Stream()
+        IStreamBuilder<TIn, TIn> IInitialStreamBuilder<TIn>.Stream()
         {
             // In memory source added.
             if (_sourceAdded)
@@ -200,7 +207,7 @@ namespace Cortex.Streams
             }
 
             _sourceAdded = true;
-            return this; // Returns IStreamBuilder<TIn, TCurrent>
+            return (IStreamBuilder<TIn, TIn>)(object)this;
         }
 
 
@@ -375,7 +382,7 @@ namespace Cortex.Streams
             return new StreamBuilder<TIn, KeyValuePair<TKey, TAggregate>>(_name, _firstOperator, _lastOperator, _sourceAdded, _telemetryProvider, _executionOptions);
         }
 
-        public IInitialStreamBuilder<TIn, TCurrent> WithTelemetry(ITelemetryProvider telemetryProvider)
+        IInitialStreamBuilder<TIn> IInitialStreamBuilder<TIn>.WithTelemetry(ITelemetryProvider telemetryProvider)
         {
             _telemetryProvider = telemetryProvider;
             return this;
@@ -723,7 +730,7 @@ namespace Cortex.Streams
             return new StreamBuilder<TIn, WindowResult<string, TCurrent>>(_name, _firstOperator, _lastOperator, _sourceAdded, _telemetryProvider, _executionOptions);
         }
 
-        public IInitialStreamBuilder<TIn, TCurrent> WithErrorHandling(StreamExecutionOptions executionOptions)
+        IInitialStreamBuilder<TIn> IInitialStreamBuilder<TIn>.WithErrorHandling(StreamExecutionOptions executionOptions)
         {
             _executionOptions = executionOptions ?? StreamExecutionOptions.Default;
             _executionOptions.StreamName = _name;

--- a/src/Cortex.Tests/Streams/Tests/ErrorHandlingTests.cs
+++ b/src/Cortex.Tests/Streams/Tests/ErrorHandlingTests.cs
@@ -29,7 +29,7 @@ namespace Cortex.Streams.Tests
                 ErrorHandlingStrategy = ErrorHandlingStrategy.Skip
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("SkipStrategyTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -63,7 +63,7 @@ namespace Cortex.Streams.Tests
                 ErrorHandlingStrategy = ErrorHandlingStrategy.Skip
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("SkipFilterTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -97,7 +97,7 @@ namespace Cortex.Streams.Tests
                 ErrorHandlingStrategy = ErrorHandlingStrategy.Skip
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("SkipSinkTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -131,7 +131,7 @@ namespace Cortex.Streams.Tests
                 ErrorHandlingStrategy = ErrorHandlingStrategy.Skip
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("SkipFlatMapTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -171,7 +171,7 @@ namespace Cortex.Streams.Tests
                 RetryDelay = TimeSpan.Zero
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("RetryTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -207,7 +207,7 @@ namespace Cortex.Streams.Tests
                 RetryDelay = TimeSpan.Zero
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("RetryExceededTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -245,7 +245,7 @@ namespace Cortex.Streams.Tests
             };
 
             var attemptCount = 0;
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("RetryDelayTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -288,7 +288,7 @@ namespace Cortex.Streams.Tests
                 ErrorHandlingStrategy = ErrorHandlingStrategy.Stop
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("StopTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -321,7 +321,7 @@ namespace Cortex.Streams.Tests
                 ErrorHandlingStrategy = ErrorHandlingStrategy.Stop
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("StopGracefulTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -355,7 +355,7 @@ namespace Cortex.Streams.Tests
         public void RethrowStrategy_PropagatesOriginalException()
         {
             // Arrange - No error handling configured means Rethrow
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("RethrowTest")
                 .Stream()
                 .Map(x =>
@@ -382,7 +382,7 @@ namespace Cortex.Streams.Tests
                 ErrorHandlingStrategy = ErrorHandlingStrategy.None
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("NoneTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -423,7 +423,7 @@ namespace Cortex.Streams.Tests
                 }
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("CustomHandlerTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -462,7 +462,7 @@ namespace Cortex.Streams.Tests
                 }
             };
 
-            var stream = StreamBuilder<string, int>
+            var stream = StreamBuilder<string>
                 .CreateNewStream("ContextTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -506,7 +506,7 @@ namespace Cortex.Streams.Tests
             };
 
             var attemptCount = 0;
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("AttemptTrackingTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -540,7 +540,7 @@ namespace Cortex.Streams.Tests
                 OnError = ctx => ErrorHandlingDecision.Stop
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("ForceStopTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -592,7 +592,7 @@ namespace Cortex.Streams.Tests
                 ErrorHandlingStrategy = ErrorHandlingStrategy.Stop
             };
 
-            var stream = StreamBuilder<int, string>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("OperatorNameTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -634,7 +634,7 @@ namespace Cortex.Streams.Tests
                 }
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("PropagationTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -689,7 +689,7 @@ namespace Cortex.Streams.Tests
             };
 
             var processedItems = new List<string>();
-            var stream = StreamBuilder<string, string>
+            var stream = StreamBuilder<string>
                 .CreateNewStream("NullInputTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -714,7 +714,7 @@ namespace Cortex.Streams.Tests
             var options1 = new StreamExecutionOptions { ErrorHandlingStrategy = ErrorHandlingStrategy.Skip };
             var options2 = new StreamExecutionOptions { ErrorHandlingStrategy = ErrorHandlingStrategy.Stop };
 
-            var stream1 = StreamBuilder<int, int>
+            var stream1 = StreamBuilder<int>
                 .CreateNewStream("Stream1")
                 .WithErrorHandling(options1)
                 .Stream()
@@ -726,7 +726,7 @@ namespace Cortex.Streams.Tests
                 .Sink(x => results1.Add(x))
                 .Build();
 
-            var stream2 = StreamBuilder<int, int>
+            var stream2 = StreamBuilder<int>
                 .CreateNewStream("Stream2")
                 .WithErrorHandling(options2)
                 .Stream()
@@ -766,7 +766,7 @@ namespace Cortex.Streams.Tests
                 MaxRetries = 0 // No retries allowed
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("ZeroRetriesTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -800,7 +800,7 @@ namespace Cortex.Streams.Tests
                 ErrorHandlingStrategy = ErrorHandlingStrategy.Stop
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("StackTraceTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -832,7 +832,7 @@ namespace Cortex.Streams.Tests
                 ErrorHandlingStrategy = ErrorHandlingStrategy.Skip
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("ComplexPipelineTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -884,7 +884,7 @@ namespace Cortex.Streams.Tests
                 ErrorHandlingStrategy = ErrorHandlingStrategy.Skip
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("AsyncEmitTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()
@@ -1045,7 +1045,7 @@ namespace Cortex.Streams.Tests
                 }
             };
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("ThreadSafetyTest")
                 .WithErrorHandling(executionOptions)
                 .Stream()

--- a/src/Cortex.Tests/Streams/Tests/FlatMapOperatorTests.cs
+++ b/src/Cortex.Tests/Streams/Tests/FlatMapOperatorTests.cs
@@ -28,7 +28,7 @@ namespace Cortex.Tests.Streams.Tests
 
             // Build the stream:
             // Start a stream without a dedicated source, we will just Emit into it.
-            var stream = StreamBuilder<string, string>
+            var stream = StreamBuilder<string>
                 .CreateNewStream("TestStream")
                 .Stream()
                 .FlatMap(line => line.Split(' '))   // Use FlatMap to split a sentence into words
@@ -56,7 +56,7 @@ namespace Cortex.Tests.Streams.Tests
             // Arrange
             var collectingSink = new CollectingSink<int>();
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("EmptyResultStream")
                 .Stream()
                 .FlatMap(num => new int[0]) // Always empty
@@ -80,7 +80,7 @@ namespace Cortex.Tests.Streams.Tests
             // Arrange
             var collectingSink = new CollectingSink<int>();
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("NullResultStream")
                 .Stream()
                 .FlatMap<int>(num => null) // Always null
@@ -104,7 +104,7 @@ namespace Cortex.Tests.Streams.Tests
             // Arrange
             var collectingSink = new CollectingSink<int>();
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("ExceptionStream")
                 .Stream()
                 .FlatMap<int>(num => throw new InvalidOperationException("Test exception"))
@@ -126,7 +126,7 @@ namespace Cortex.Tests.Streams.Tests
             // Arrange
             var collectingSink = new CollectingSink<string>();
 
-            var stream = StreamBuilder<string, string>
+            var stream = StreamBuilder<string>
                 .CreateNewStream("SingleOutputStream")
                 .Stream()
                 .FlatMap(line => new[] { line.ToUpper() }) // One-to-one mapping but via flatmap

--- a/src/Cortex.Tests/Streams/Tests/SessionWindowOperatorTests.cs
+++ b/src/Cortex.Tests/Streams/Tests/SessionWindowOperatorTests.cs
@@ -289,7 +289,7 @@ namespace Cortex.Streams.Tests
             var inactivityGap = TimeSpan.FromSeconds(2);
             var emittedResults = new List<WindowResult<string, InputData>>();
 
-            var stream = StreamBuilder<InputData, InputData>
+            var stream = StreamBuilder<InputData>
                 .CreateNewStream("Test Session Window Stream")
                 .Stream()
                 .SessionWindow<string>(

--- a/src/Cortex.Tests/Streams/Tests/SlidingWindowOperatorTests.cs
+++ b/src/Cortex.Tests/Streams/Tests/SlidingWindowOperatorTests.cs
@@ -210,7 +210,7 @@ namespace Cortex.Streams.Tests
             var slideInterval = TimeSpan.FromSeconds(1);
             var emittedResults = new List<WindowResult<string, InputData>>();
 
-            var stream = StreamBuilder<InputData, InputData>
+            var stream = StreamBuilder<InputData>
                 .CreateNewStream("Test Sliding Window Stream")
                 .Stream()
                 .SlidingWindow<string>(

--- a/src/Cortex.Tests/Streams/Tests/StreamBuilderTests.cs
+++ b/src/Cortex.Tests/Streams/Tests/StreamBuilderTests.cs
@@ -7,7 +7,7 @@
         {
             // Arrange
             var receivedData = new List<int>();
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("TestStream")
                 .Stream()
                 .Map(x => x * 2)
@@ -31,7 +31,7 @@
         public void Build_ShouldCreateStreamSuccessfully()
         {
             // Arrange
-            var builder = StreamBuilder<int, int>.CreateNewStream("TestStream")
+            var builder = StreamBuilder<int>.CreateNewStream("TestStream")
                 .Stream()
                 .Map(x => x * 2)
                 .Filter(x => x > 5);

--- a/src/Cortex.Tests/Streams/Tests/StreamIntegrationTests.cs
+++ b/src/Cortex.Tests/Streams/Tests/StreamIntegrationTests.cs
@@ -8,7 +8,7 @@
             // Arrange
             string result = null;
 
-            var stream = StreamBuilder<int, int>.CreateNewStream("TestStream")
+            var stream = StreamBuilder<int>.CreateNewStream("TestStream")
                 .Stream()
                 .Filter(x => x > 5)
                 .Map(x => x * 2)
@@ -29,7 +29,7 @@
             // Arrange
             string result = null;
 
-            var stream = StreamBuilder<int, int>.CreateNewStream("TestStream")
+            var stream = StreamBuilder<int>.CreateNewStream("TestStream")
                 .Stream()
                 .Filter(x => x > 10)
                 .Sink(x => result = $"Result: {x}")

--- a/src/Cortex.Tests/Streams/Tests/TelemetryTests.cs
+++ b/src/Cortex.Tests/Streams/Tests/TelemetryTests.cs
@@ -200,7 +200,7 @@ namespace Cortex.Tests.Streams.Tests
         {
             // Arrange
             var receivedData = new List<int>();
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("TestStreamWithoutTelemetry")
                 .Stream()
                 .Map(x => x * 2)
@@ -225,7 +225,7 @@ namespace Cortex.Tests.Streams.Tests
         {
             // Arrange
             var receivedData = new List<int>();
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("TestStreamNullTelemetry")
                 .WithTelemetry(null!)
                 .Stream()
@@ -254,7 +254,7 @@ namespace Cortex.Tests.Streams.Tests
             var (mockProvider, state) = CreateMockTelemetryProvider();
             int result = 0;
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("MapTelemetryTest")
                 .WithTelemetry(mockProvider.Object)
                 .Stream()
@@ -311,7 +311,7 @@ namespace Cortex.Tests.Streams.Tests
             var (mockProvider, state) = CreateMockTelemetryProvider();
             var receivedData = new List<int>();
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("FilterTelemetryTest")
                 .WithTelemetry(mockProvider.Object)
                 .Stream()
@@ -410,7 +410,7 @@ namespace Cortex.Tests.Streams.Tests
             var (mockProvider, state) = CreateMockTelemetryProvider();
             var receivedData = new List<int>();
 
-            var stream = StreamBuilder<string, string>
+            var stream = StreamBuilder<string>
                 .CreateNewStream("FlatMapTelemetryTest")
                 .WithTelemetry(mockProvider.Object)
                 .Stream()
@@ -444,7 +444,7 @@ namespace Cortex.Tests.Streams.Tests
             var (mockProvider, state) = CreateMockTelemetryProvider();
             var receivedGroups = new List<KeyValuePair<string, List<int>>>();
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("GroupByTelemetryTest")
                 .WithTelemetry(mockProvider.Object)
                 .Stream()
@@ -479,7 +479,7 @@ namespace Cortex.Tests.Streams.Tests
             var (mockProvider, state) = CreateMockTelemetryProvider();
             var receivedAggregates = new List<KeyValuePair<string, int>>();
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("AggregateTelemetryTest")
                 .WithTelemetry(mockProvider.Object)
                 .Stream()
@@ -516,7 +516,7 @@ namespace Cortex.Tests.Streams.Tests
             var branch1Data = new List<int>();
             var branch2Data = new List<int>();
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("BranchTelemetryTest")
                 .WithTelemetry(mockProvider.Object)
                 .Stream()
@@ -560,7 +560,7 @@ namespace Cortex.Tests.Streams.Tests
             var (mockProvider, state) = CreateMockTelemetryProvider();
             var receivedData = new List<string>();
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("E2ETelemetryTest")
                 .WithTelemetry(mockProvider.Object)
                 .Stream()
@@ -709,7 +709,7 @@ namespace Cortex.Tests.Streams.Tests
             var (mockProvider, state) = CreateMockTelemetryProvider();
             var receivedData = new System.Collections.Concurrent.ConcurrentBag<int>();
 
-            var stream = StreamBuilder<int, int>
+            var stream = StreamBuilder<int>
                 .CreateNewStream("ThreadSafeTelemetryTest")
                 .WithTelemetry(mockProvider.Object)
                 .Stream()

--- a/src/Cortex.Tests/Streams/Tests/TumblingWindowOperatorTests.cs
+++ b/src/Cortex.Tests/Streams/Tests/TumblingWindowOperatorTests.cs
@@ -248,7 +248,7 @@ namespace Cortex.Streams.Tests
             var windowSize = TimeSpan.FromSeconds(2);
             var emittedResults = new List<WindowResult<string, InputData>>();
 
-            var stream = StreamBuilder<InputData, InputData>
+            var stream = StreamBuilder<InputData>
                 .CreateNewStream("Test Tumbling Window Stream")
                 .Stream()
                 .TumblingWindow<string>(

--- a/src/Cortex.Tests/StreamsMediator/Tests/StreamBuilderMediatorExtensionsTests.cs
+++ b/src/Cortex.Tests/StreamsMediator/Tests/StreamBuilderMediatorExtensionsTests.cs
@@ -44,7 +44,7 @@ namespace Cortex.Tests.StreamsMediator.Tests
                 .ReturnsAsync("result");
 
             // Build a stream using the extension method
-            var stream = StreamBuilder<string, string>
+            var stream = StreamBuilder<string>
                 .CreateNewStream("TestStream")
                 .Stream()
                 .SinkToCommand<string, string, StreamExtensionTestCommand, string>(
@@ -80,7 +80,7 @@ namespace Cortex.Tests.StreamsMediator.Tests
                 .Returns(Task.CompletedTask);
 
             // Build a stream using the extension method
-            var stream = StreamBuilder<string, string>
+            var stream = StreamBuilder<string>
                 .CreateNewStream("TestStream")
                 .Stream()
                 .SinkToVoidCommand<string, string, StreamExtensionVoidCommand>(
@@ -115,7 +115,7 @@ namespace Cortex.Tests.StreamsMediator.Tests
                 .Returns(Task.CompletedTask);
 
             // Build a stream using the extension method
-            var stream = StreamBuilder<string, string>
+            var stream = StreamBuilder<string>
                 .CreateNewStream("TestStream")
                 .Stream()
                 .SinkToNotification<string, string, StreamExtensionNotification>(
@@ -150,7 +150,7 @@ namespace Cortex.Tests.StreamsMediator.Tests
                 .Returns(Task.CompletedTask);
 
             // Build a stream using the extension method - starts with notification type
-            var stream = StreamBuilder<StreamExtensionNotification, StreamExtensionNotification>
+            var stream = StreamBuilder<StreamExtensionNotification>
                 .CreateNewStream("NotificationStream")
                 .Stream()
                 .PublishNotification(mockMediator.Object)
@@ -182,7 +182,7 @@ namespace Cortex.Tests.StreamsMediator.Tests
                 .ReturnsAsync((StreamExtensionTestCommand cmd, CancellationToken _) => $"processed-{cmd.Input}");
 
             // Build a stream using the extension method
-            var stream = StreamBuilder<string, string>
+            var stream = StreamBuilder<string>
                 .CreateNewStream("TestStream")
                 .Stream()
                 .SinkToCommand<string, string, StreamExtensionTestCommand, string>(
@@ -216,7 +216,7 @@ namespace Cortex.Tests.StreamsMediator.Tests
                 .ThrowsAsync(new InvalidOperationException("Test error"));
 
             // Build a stream using the extension method
-            var stream = StreamBuilder<string, string>
+            var stream = StreamBuilder<string>
                 .CreateNewStream("TestStream")
                 .Stream()
                 .SinkToCommand<string, string, StreamExtensionTestCommand, string>(
@@ -252,7 +252,7 @@ namespace Cortex.Tests.StreamsMediator.Tests
                 .Returns(Task.CompletedTask);
 
             // Build a stream using the extension method
-            var stream = StreamBuilder<string, string>
+            var stream = StreamBuilder<string>
                 .CreateNewStream("TestStream")
                 .Stream()
                 .SinkToNotification<string, string, StreamExtensionNotification>(


### PR DESCRIPTION
Refactored the stream builder API to remove the second type parameter (TCurrent) from IInitialStreamBuilder and StreamBuilder. Stream creation now starts with StreamBuilder<TIn>.CreateNewStream("Name"), returning IInitialStreamBuilder<TIn>. All builder methods now operate on TIn as the initial/current type. Updated all usages, extension methods, tests, and documentation to use the new API. This change makes the API more intuitive, reduces boilerplate, and improves usability while preserving type safety and flexibility.

#185 