### PR TITLE
Support continuation after ForkOperator and fix branch bug

### DIFF
--- a/src/Cortex.Streams/Operators/ForkOperator.cs
+++ b/src/Cortex.Streams/Operators/ForkOperator.cs
@@ -8,6 +8,7 @@ namespace Cortex.Streams.Operators
     internal class ForkOperator<T> : IOperator, IHasNextOperators, ITelemetryEnabled
     {
         private readonly Dictionary<string, BranchOperator<T>> _branches = new Dictionary<string, BranchOperator<T>>();
+        private IOperator _continuationOperator;
 
         // Telemetry fields
         private ITelemetryProvider _telemetryProvider;
@@ -46,6 +47,12 @@ namespace Cortex.Streams.Operators
                     telemetryEnabled.SetTelemetryProvider(telemetryProvider);
                 }
             }
+
+            // Propagate telemetry to the continuation operator
+            if (_continuationOperator is ITelemetryEnabled continuationTelemetryEnabled)
+            {
+                continuationTelemetryEnabled.SetTelemetryProvider(telemetryProvider);
+            }
         }
 
         public void AddBranch(string name, BranchOperator<T> branchOperator)
@@ -79,6 +86,10 @@ namespace Cortex.Streams.Operators
                         {
                             branch.Process(input);
                         }
+
+                        // Process continuation operator after branches
+                        _continuationOperator?.Process(input);
+
                         span.SetAttribute("status", "success");
                     }
                     catch (Exception ex)
@@ -101,17 +112,34 @@ namespace Cortex.Streams.Operators
                 {
                     branch.Process(input);
                 }
+
+                // Process continuation operator after branches
+                _continuationOperator?.Process(input);
             }
         }
 
         public void SetNext(IOperator nextOperator)
         {
-            throw new InvalidOperationException("Cannot set next operator on a ForkOperator.");
+            _continuationOperator = nextOperator;
+
+            // Propagate telemetry to the new continuation operator if already configured
+            if (_telemetryProvider != null && nextOperator is ITelemetryEnabled telemetryEnabled)
+            {
+                telemetryEnabled.SetTelemetryProvider(_telemetryProvider);
+            }
         }
 
         public IEnumerable<IOperator> GetNextOperators()
         {
-            return _branches.Values;
+            foreach (var branch in _branches.Values)
+            {
+                yield return branch;
+            }
+
+            if (_continuationOperator != null)
+            {
+                yield return _continuationOperator;
+            }
         }
 
         public IReadOnlyDictionary<string, BranchOperator<T>> Branches => _branches;

--- a/src/Cortex.Tests/Streams/Tests/StreamBuilderTests.cs
+++ b/src/Cortex.Tests/Streams/Tests/StreamBuilderTests.cs
@@ -42,5 +42,95 @@
             // Assert
             Assert.NotNull(stream);
         }
+
+        [Fact]
+        public void StreamBuilder_WithBranchesAndSink_ShouldProcessBothBranchesAndMainSink()
+        {
+            // Arrange - Bug scenario: branches not triggered when Sink in main pipeline
+            var branch1Data = new List<int>();
+            var branch2Data = new List<int>();
+            var mainSinkData = new List<int>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestStreamWithBranchesAndSink")
+                .Stream()
+                .Map(x => x * 2)
+                .AddBranch("EvenBranch", branch => branch
+                    .Filter(x => x % 4 == 0)
+                    .Sink(x => branch1Data.Add(x)))
+                .AddBranch("OddBranch", branch => branch
+                    .Filter(x => x % 4 != 0)
+                    .Sink(x => branch2Data.Add(x)))
+                .Sink(x => mainSinkData.Add(x))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(1);  // -> 2 (branch2, main)
+            stream.Emit(2);  // -> 4 (branch1, main)
+            stream.Emit(3);  // -> 6 (branch2, main)
+            stream.Emit(4);  // -> 8 (branch1, main)
+
+            // Assert - All branches and main sink should receive data
+            Assert.Equal(new[] { 4, 8 }, branch1Data);      // Even multiples of 4
+            Assert.Equal(new[] { 2, 6 }, branch2Data);      // Not multiples of 4
+            Assert.Equal(new[] { 2, 4, 6, 8 }, mainSinkData); // All data flows to main sink
+        }
+
+        [Fact]
+        public void StreamBuilder_WithBranchesAndMapAfterBranch_ShouldContinueProcessingAfterFork()
+        {
+            // Arrange - Test that Map works after branches
+            var branchData = new List<int>();
+            var mainSinkData = new List<string>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestStreamMapAfterBranch")
+                .Stream()
+                .AddBranch("NumberBranch", branch => branch
+                    .Sink(x => branchData.Add(x)))
+                .Map(x => $"Value: {x}")
+                .Sink(x => mainSinkData.Add(x))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(1);
+            stream.Emit(2);
+
+            // Assert
+            Assert.Equal(new[] { 1, 2 }, branchData);
+            Assert.Equal(new[] { "Value: 1", "Value: 2" }, mainSinkData);
+        }
+
+        [Fact]
+        public void StreamBuilder_WithBranchesAndFilterAfterBranch_ShouldContinueProcessingAfterFork()
+        {
+            // Arrange - Test that Filter works after branches
+            var branchData = new List<int>();
+            var mainSinkData = new List<int>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestStreamFilterAfterBranch")
+                .Stream()
+                .AddBranch("AllBranch", branch => branch
+                    .Sink(x => branchData.Add(x)))
+                .Filter(x => x > 5)
+                .Sink(x => mainSinkData.Add(x))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(3);
+            stream.Emit(7);
+            stream.Emit(10);
+
+            // Assert
+            Assert.Equal(new[] { 3, 7, 10 }, branchData);  // Branch gets all data
+            Assert.Equal(new[] { 7, 10 }, mainSinkData);   // Main sink only gets filtered data
+        }
     }
 }


### PR DESCRIPTION
Enhance ForkOperator to allow a continuation operator after branching, enabling the main pipeline to continue processing after a fork. Telemetry propagation now includes the continuation operator. Updated GetNextOperators and Process methods to support this flow. Added tests to verify correct processing of branches and downstream operators. Fixes bug where downstream operators after a fork were not invoked.