### PR TITLE
Add FanOut: multi-sink stream support with filters

### DIFF
--- a/docs/wiki/FanOut-Multiple-Sinks.md
+++ b/docs/wiki/FanOut-Multiple-Sinks.md
@@ -1,0 +1,564 @@
+# FanOut - Multiple Sinks Pattern
+
+**FanOut** is a powerful stream processing pattern in Cortex.Streams that allows you to send the same data to multiple destinations (sinks) simultaneously. This is essential for scenarios like dual-writes, multi-channel notifications, real-time analytics, and audit logging.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [When to Use FanOut](#when-to-use-fanout)
+- [FanOut vs AddBranch](#fanout-vs-addbranch)
+- [Basic Usage](#basic-usage)
+- [API Reference](#api-reference)
+- [Real-World Examples](#real-world-examples)
+  - [E-Commerce Order Processing](#e-commerce-order-processing)
+  - [IoT Sensor Data Processing](#iot-sensor-data-processing)
+  - [Log Aggregation Pipeline](#log-aggregation-pipeline)
+  - [Financial Transaction Processing](#financial-transaction-processing)
+  - [User Activity Tracking](#user-activity-tracking)
+- [Best Practices](#best-practices)
+- [Error Handling](#error-handling)
+- [Performance Considerations](#performance-considerations)
+
+---
+
+## Overview
+
+The FanOut pattern enables a stream to broadcast data to multiple sinks in parallel. Each sink operates independently and can optionally have its own filter predicate to receive only matching data.
+
+```
+                    ???????????????????
+                    ?    Database     ?
+                    ???????????????????
+                            ?
+                            ?
+????????????    ?????????????????????????    ???????????????????
+?  Source  ??????       FanOut          ??????     Kafka       ?
+????????????    ?????????????????????????    ???????????????????
+                            ?
+                            ?
+                    ???????????????????
+                    ?     Alerts      ?
+                    ?  (filtered)     ?
+                    ???????????????????
+```
+
+## When to Use FanOut
+
+Use FanOut when you need to:
+
+- **Dual-write** to multiple storage systems (database + cache)
+- **Publish events** to multiple message brokers
+- **Send notifications** to multiple channels (email, SMS, push)
+- **Feed multiple analytics** systems from the same data source
+- **Create audit trails** while processing data
+- **Route data conditionally** to different sinks based on criteria
+
+## FanOut vs AddBranch
+
+| Feature | `FanOut` | `AddBranch` |
+|---------|----------|-------------|
+| **Purpose** | Multiple sinks, same or filtered data | Complex branching with transformations |
+| **API Style** | Fluent, focused on sinks | Configuration-based, full pipeline control |
+| **Transformations** | Per-sink via `ToWithTransform` | Full pipeline per branch |
+| **Use Case** | Simple fan-out to multiple destinations | Different processing logic per branch |
+| **Complexity** | Simple | More flexible but complex |
+
+**Rule of thumb:** Use `FanOut` when you need multiple sinks with optional filtering. Use `AddBranch` when each branch needs different transformation logic.
+
+## Basic Usage
+
+### Simple Multi-Sink
+
+```csharp
+var stream = StreamBuilder<Order>.CreateNewStream("OrderProcessor")
+    .Stream()
+    .FanOut(fanOut => fanOut
+        .To("database", order => SaveToDatabase(order))
+        .To("kafka", order => PublishToKafka(order))
+        .To("logging", order => LogOrder(order)))
+    .Build();
+
+stream.Start();
+stream.Emit(new Order { Id = "ORD-001", Amount = 100 });
+```
+
+### With Filtering
+
+```csharp
+var stream = StreamBuilder<Order>.CreateNewStream("OrderProcessor")
+    .Stream()
+    .FanOut(fanOut => fanOut
+        // All orders to database
+        .To("database", order => SaveToDatabase(order))
+        // Only high-value orders to alerts
+        .To("alerts", 
+            order => order.Amount > 10000, 
+            order => SendAlert(order))
+        // Only priority orders to fast-track queue
+        .To("priority-queue",
+            order => order.IsPriority,
+            order => EnqueuePriority(order)))
+    .Build();
+```
+
+### With Transformation
+
+```csharp
+var stream = StreamBuilder<Order>.CreateNewStream("OrderProcessor")
+    .Stream()
+    .FanOut(fanOut => fanOut
+        // Store original order
+        .To("database", order => SaveOrder(order))
+        // Transform to event for Kafka
+        .ToWithTransform("kafka",
+            order => new OrderEvent(order.Id, "Created", DateTime.UtcNow),
+            evt => PublishEvent(evt))
+        // Transform to metrics for analytics
+        .ToWithTransform("analytics",
+            order => new OrderMetrics(order.Id, order.Amount),
+            metrics => RecordMetrics(metrics)))
+    .Build();
+```
+
+## API Reference
+
+### `IFanOutBuilder<TIn, TCurrent>`
+
+| Method | Description |
+|--------|-------------|
+| `To(string name, Action<TCurrent> sinkFunction)` | Adds a named sink that receives all data |
+| `To(string name, Func<TCurrent, bool> predicate, Action<TCurrent> sinkFunction)` | Adds a filtered sink |
+| `To(string name, ISinkOperator<TCurrent> sinkOperator)` | Adds a custom sink operator |
+| `To(string name, Func<TCurrent, bool> predicate, ISinkOperator<TCurrent> sinkOperator)` | Adds a filtered custom sink operator |
+| `ToWithTransform<TOutput>(string name, Func<TCurrent, TOutput> mapFunction, Action<TOutput> sinkFunction)` | Adds a sink with per-sink transformation |
+| `Build()` | Builds the stream with all configured sinks |
+
+### Important Notes
+
+- **Sink names must be unique** within a FanOut
+- **At least one sink** must be configured before calling `Build()`
+- Sinks are executed in parallel (order not guaranteed)
+- Each sink is independent - one sink's failure doesn't affect others (with proper error handling)
+
+---
+
+## Real-World Examples
+
+### E-Commerce Order Processing
+
+Process orders and distribute to multiple systems simultaneously:
+
+```csharp
+public class OrderProcessor
+{
+    private readonly IOrderRepository _repository;
+    private readonly IKafkaProducer _kafka;
+    private readonly IAlertService _alerts;
+    private readonly IAnalyticsService _analytics;
+
+    public void SetupPipeline()
+    {
+        var stream = StreamBuilder<Order>.CreateNewStream("OrderProcessingPipeline")
+            .Stream()
+            // Only process confirmed orders
+            .Filter(order => order.Status == OrderStatus.Confirmed)
+            .FanOut(fanOut => fanOut
+                // 1. Persist to database (primary storage)
+                .To("database", order => 
+                    _repository.SaveAsync(order).GetAwaiter().GetResult())
+                
+                // 2. Publish to Kafka for downstream consumers
+                .ToWithTransform("kafka-events",
+                    order => new OrderConfirmedEvent
+                    {
+                        OrderId = order.Id,
+                        CustomerId = order.CustomerId,
+                        Amount = order.TotalAmount,
+                        Timestamp = DateTime.UtcNow
+                    },
+                    evt => _kafka.PublishAsync("order-events", evt).GetAwaiter().GetResult())
+                
+                // 3. Alert on high-value orders (> $10,000)
+                .To("high-value-alerts",
+                    order => order.TotalAmount > 10000,
+                    order => _alerts.SendHighValueOrderAlert(order))
+                
+                // 4. Send metrics to analytics
+                .ToWithTransform("analytics",
+                    order => new OrderMetrics
+                    {
+                        OrderId = order.Id,
+                        Amount = order.TotalAmount,
+                        ItemCount = order.Items.Count,
+                        Region = order.ShippingAddress.Region
+                    },
+                    metrics => _analytics.RecordOrderMetrics(metrics)))
+            .Build();
+
+        stream.Start();
+        return stream;
+    }
+}
+```
+
+### IoT Sensor Data Processing
+
+Route sensor data to different storage tiers based on criticality:
+
+```csharp
+public class SensorDataPipeline
+{
+    public IStream<SensorReading, SensorReading> Create()
+    {
+        return StreamBuilder<SensorReading>.CreateNewStream("SensorDataPipeline")
+            .Stream()
+            .FanOut(fanOut => fanOut
+                // Archive ALL readings to cold storage
+                .To("cold-storage", reading => 
+                    _coldStorage.Archive(reading))
+                
+                // Critical readings (temp > 100°C) - immediate alert
+                .To("critical-alerts",
+                    reading => reading.Temperature > 100,
+                    reading => 
+                    {
+                        _pagerDuty.TriggerAlert($"CRITICAL: {reading.SensorId} at {reading.Temperature}°C");
+                        _hotStorage.Store(reading); // Also store in hot storage
+                    })
+                
+                // Warning readings (80-100°C) - log for review
+                .To("warning-log",
+                    reading => reading.Temperature >= 80 && reading.Temperature <= 100,
+                    reading => _warningLogger.Log(reading))
+                
+                // Normal readings to time-series DB
+                .To("timeseries-db",
+                    reading => reading.Temperature < 80,
+                    reading => _timeSeriesDb.Insert(reading))
+                
+                // All readings to real-time dashboard
+                .ToWithTransform("dashboard",
+                    reading => new DashboardUpdate
+                    {
+                        SensorId = reading.SensorId,
+                        Value = reading.Temperature,
+                        Status = GetStatus(reading.Temperature),
+                        Timestamp = reading.Timestamp
+                    },
+                    update => _dashboard.Push(update)))
+            .Build();
+    }
+
+    private string GetStatus(double temp) => temp switch
+    {
+        > 100 => "CRITICAL",
+        >= 80 => "WARNING",
+        _ => "NORMAL"
+    };
+}
+```
+
+### Log Aggregation Pipeline
+
+Aggregate logs from multiple services and route by severity:
+
+```csharp
+public class LogAggregationPipeline
+{
+    public IStream<LogEntry, LogEntry> Create()
+    {
+        return StreamBuilder<LogEntry>.CreateNewStream("LogAggregation")
+            .Stream()
+            // Enrich logs with metadata
+            .Map(log => log with 
+            { 
+                ProcessedAt = DateTime.UtcNow,
+                Environment = Environment.GetEnvironmentVariable("ENV") 
+            })
+            .FanOut(fanOut => fanOut
+                // All logs to Elasticsearch for search
+                .To("elasticsearch", log => 
+                    _elasticsearch.IndexAsync("logs", log).GetAwaiter().GetResult())
+                
+                // Errors to PagerDuty for on-call
+                .To("pagerduty",
+                    log => log.Level == LogLevel.Error,
+                    log => _pagerDuty.CreateIncident(new Incident
+                    {
+                        Title = $"[{log.Service}] {log.Message}",
+                        Severity = "high",
+                        Details = log.StackTrace
+                    }))
+                
+                // Warnings to Slack channel
+                .To("slack",
+                    log => log.Level == LogLevel.Warning,
+                    log => _slack.PostMessage("#alerts", 
+                        $"?? [{log.Service}] {log.Message}"))
+                
+                // Metrics to Prometheus
+                .ToWithTransform("prometheus",
+                    log => new LogMetric
+                    {
+                        Service = log.Service,
+                        Level = log.Level.ToString(),
+                        Count = 1
+                    },
+                    metric => _prometheus.IncrementCounter(
+                        "log_entries_total",
+                        new[] { metric.Service, metric.Level }))
+                
+                // Long-term archive to S3
+                .To("s3-archive",
+                    log => _s3.PutObjectAsync($"logs/{log.Timestamp:yyyy/MM/dd}/{log.Id}.json", 
+                        JsonSerializer.Serialize(log)).GetAwaiter().GetResult()))
+            .Build();
+    }
+}
+```
+
+### Financial Transaction Processing
+
+Process transactions with multiple compliance checks:
+
+```csharp
+public class TransactionPipeline
+{
+    public IStream<Transaction, Transaction> Create()
+    {
+        return StreamBuilder<Transaction>.CreateNewStream("TransactionProcessing")
+            .Stream()
+            .FanOut(fanOut => fanOut
+                // Main ledger - all transactions
+                .To("ledger", txn => 
+                    _ledger.RecordTransaction(txn))
+                
+                // Fraud detection - suspicious patterns
+                .To("fraud-detection",
+                    txn => txn.Amount > 10000 && txn.Type == TransactionType.International,
+                    txn => _fraudService.AnalyzeAsync(txn).GetAwaiter().GetResult())
+                
+                // Regulatory reporting - CTR for transactions > $10,000
+                .To("regulatory-ctr",
+                    txn => txn.Amount > 10000,
+                    txn => _compliance.FileCTR(new CurrencyTransactionReport
+                    {
+                        TransactionId = txn.Id,
+                        Amount = txn.Amount,
+                        AccountHolder = txn.AccountHolder,
+                        FilingDate = DateTime.UtcNow
+                    }))
+                
+                // Sanctions screening - international transactions
+                .To("sanctions-screening",
+                    txn => txn.Type == TransactionType.International,
+                    txn => _sanctions.ScreenTransaction(txn))
+                
+                // Audit trail - immutable record
+                .ToWithTransform("audit-log",
+                    txn => new AuditEntry
+                    {
+                        EntityType = "Transaction",
+                        EntityId = txn.Id,
+                        Action = "PROCESSED",
+                        Timestamp = DateTime.UtcNow,
+                        Details = JsonSerializer.Serialize(txn)
+                    },
+                    entry => _auditLog.Append(entry))
+                
+                // Real-time balance update
+                .To("balance-service",
+                    txn => _balanceService.UpdateBalance(txn.AccountId, txn.Amount)))
+            .Build();
+    }
+}
+```
+
+### User Activity Tracking
+
+Track user activity across multiple analytics platforms:
+
+```csharp
+public class UserActivityPipeline
+{
+    public IStream<UserActivity, UserActivity> Create()
+    {
+        return StreamBuilder<UserActivity>.CreateNewStream("UserActivityTracking")
+            .Stream()
+            .FanOut(fanOut => fanOut
+                // Raw clickstream to data lake
+                .To("data-lake", activity => 
+                    _dataLake.Store("clickstream", activity))
+                
+                // Page views to Google Analytics
+                .To("google-analytics",
+                    activity => activity.Type == ActivityType.PageView,
+                    activity => _ga.TrackPageView(activity.UserId, activity.PageUrl))
+                
+                // Purchases to commerce analytics
+                .To("commerce-analytics",
+                    activity => activity.Type == ActivityType.Purchase,
+                    activity => _commerce.TrackPurchase(new PurchaseEvent
+                    {
+                        UserId = activity.UserId,
+                        ProductId = activity.Details,
+                        Timestamp = activity.Timestamp
+                    }))
+                
+                // Search queries for search optimization
+                .To("search-analytics",
+                    activity => activity.Type == ActivityType.Search,
+                    activity => _searchAnalytics.RecordQuery(activity.Details))
+                
+                // Session metrics for engagement
+                .ToWithTransform("session-metrics",
+                    activity => new SessionMetric
+                    {
+                        SessionId = activity.SessionId,
+                        UserId = activity.UserId,
+                        ActivityCount = 1,
+                        LastActivity = activity.Timestamp
+                    },
+                    metric => _sessions.UpdateMetrics(metric))
+                
+                // Real-time personalization engine
+                .To("personalization",
+                    activity => _personalization.UpdateUserProfile(activity)))
+            .Build();
+    }
+}
+```
+
+---
+
+## Best Practices
+
+### 1. Use Meaningful Sink Names
+
+```csharp
+// ? Good - descriptive names
+.To("order-database", ...)
+.To("kafka-order-events", ...)
+.To("high-value-alerts", ...)
+
+// ? Avoid - generic names
+.To("sink1", ...)
+.To("output", ...)
+```
+
+### 2. Handle Errors Per Sink
+
+```csharp
+.To("database", order => 
+{
+    try 
+    {
+        _repository.Save(order);
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Failed to save order {OrderId}", order.Id);
+        _deadLetterQueue.Enqueue(order);
+    }
+})
+```
+
+### 3. Use Async Patterns Appropriately
+
+```csharp
+// For I/O-bound operations, consider async wrappers
+.To("database", order => 
+    _repository.SaveAsync(order).GetAwaiter().GetResult())
+```
+
+### 4. Apply Filters at FanOut Level
+
+```csharp
+// ? Good - filter at FanOut level
+.FanOut(fanOut => fanOut
+    .To("alerts", order => order.Amount > 10000, order => SendAlert(order)))
+
+// ? Less efficient - filtering inside sink
+.FanOut(fanOut => fanOut
+    .To("alerts", order => 
+    {
+        if (order.Amount > 10000) // Avoid this
+            SendAlert(order);
+    }))
+```
+
+### 5. Keep Transformations Simple
+
+```csharp
+// ? Good - simple transformation
+.ToWithTransform("events", 
+    order => new OrderEvent(order.Id, order.Status),
+    evt => Publish(evt))
+
+// ? Avoid - complex logic in transform
+.ToWithTransform("events",
+    order => 
+    {
+        // Don't put complex logic here
+        var result = ComplexCalculation(order);
+        return new OrderEvent(result);
+    },
+    evt => Publish(evt))
+```
+
+---
+
+## Error Handling
+
+Configure error handling at the stream level:
+
+```csharp
+var stream = StreamBuilder<Order>.CreateNewStream("OrderProcessor")
+    .WithErrorHandling(options => 
+    {
+        options.OnError = (ex, item) => 
+        {
+            _logger.LogError(ex, "Error processing {Item}", item);
+            return ErrorAction.Continue; // or Skip, Retry, Stop
+        };
+        options.MaxRetries = 3;
+        options.RetryDelay = TimeSpan.FromSeconds(1);
+    })
+    .Stream()
+    .FanOut(fanOut => fanOut
+        .To("database", order => SaveOrder(order))
+        .To("kafka", order => PublishEvent(order)))
+    .Build();
+```
+
+---
+
+## Performance Considerations
+
+1. **Sink Execution**: Sinks execute sequentially within the FanOut operator. For high-throughput scenarios, consider using async patterns or dedicated thread pools.
+
+2. **Filter Early**: Apply filters to reduce data volume before expensive operations.
+
+3. **Monitor Sink Latency**: Use telemetry to identify slow sinks that may become bottlenecks.
+
+4. **Consider Buffering**: For bursty workloads, consider adding buffering before slow sinks.
+
+```csharp
+// Example: Monitor FanOut performance
+var stream = StreamBuilder<Order>.CreateNewStream("OrderProcessor")
+    .WithTelemetry(telemetryProvider)  // Enables per-sink metrics
+    .Stream()
+    .FanOut(fanOut => fanOut
+        .To("fast-sink", order => FastOperation(order))
+        .To("slow-sink", order => SlowOperation(order)))
+    .Build();
+```
+
+---
+
+## Related Documentation
+
+- [Stream Processing Basics](./stream-processing-basics.md)
+- [Branching with AddBranch](./branching.md)
+- [Error Handling](./error-handling.md)
+- [Telemetry and Monitoring](./telemetry.md)

--- a/src/Cortex.Streams/Abstractions/IFanOutBuilder.cs
+++ b/src/Cortex.Streams/Abstractions/IFanOutBuilder.cs
@@ -1,0 +1,131 @@
+using Cortex.Streams.Operators;
+using System;
+
+namespace Cortex.Streams.Abstractions
+{
+    /// <summary>
+    /// Builder for configuring multiple sink outputs in a fan-out pattern.
+    /// Fan-out allows sending the same data to multiple destinations simultaneously,
+    /// which is useful for scenarios like dual-writes, multi-channel notifications,
+    /// or parallel processing pipelines.
+    /// </summary>
+    /// <typeparam name="TIn">The type of the initial input to the stream.</typeparam>
+    /// <typeparam name="TCurrent">The current type of data being processed.</typeparam>
+    /// <remarks>
+    /// <para>
+    /// Use <see cref="IFanOutBuilder{TIn, TCurrent}"/> when you need to send data to multiple
+    /// sinks without intermediate transformations. For complex branching with transformations,
+    /// use <see cref="IStreamBuilder{TIn, TCurrent}.AddBranch"/> instead.
+    /// </para>
+    /// <example>
+    /// <code>
+    /// var stream = StreamBuilder&lt;Order&gt;.CreateNewStream("OrderProcessor")
+    ///     .Stream()
+    ///     .Map(order => EnrichOrder(order))
+    ///     .FanOut(fanOut => fanOut
+    ///         .To("database", order => SaveToDatabase(order))
+    ///         .To("kafka", order => PublishToKafka(order))
+    ///         .To("alerts", order => order.Amount > 10000, order => SendAlert(order)))
+    ///     .Build();
+    /// </code>
+    /// </example>
+    /// </remarks>
+    public interface IFanOutBuilder<TIn, TCurrent>
+    {
+        /// <summary>
+        /// Adds a named sink to the fan-out that receives all data.
+        /// </summary>
+        /// <param name="name">The unique name of the sink for identification and telemetry.</param>
+        /// <param name="sinkFunction">The action to consume data.</param>
+        /// <returns>The fan-out builder for method chaining.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="sinkFunction"/> is null.</exception>
+        /// <example>
+        /// <code>
+        /// .FanOut(fanOut => fanOut
+        ///     .To("console", x => Console.WriteLine(x))
+        ///     .To("file", x => File.AppendAllText("log.txt", x.ToString())))
+        /// </code>
+        /// </example>
+        IFanOutBuilder<TIn, TCurrent> To(string name, Action<TCurrent> sinkFunction);
+
+        /// <summary>
+        /// Adds a named sink to the fan-out with a filter predicate.
+        /// Only data that matches the predicate will be sent to this sink.
+        /// </summary>
+        /// <param name="name">The unique name of the sink for identification and telemetry.</param>
+        /// <param name="predicate">A filter predicate that determines which data reaches this sink.</param>
+        /// <param name="sinkFunction">The action to consume filtered data.</param>
+        /// <returns>The fan-out builder for method chaining.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="predicate"/> or <paramref name="sinkFunction"/> is null.</exception>
+        /// <example>
+        /// <code>
+        /// .FanOut(fanOut => fanOut
+        ///     .To("all-orders", order => _repository.Save(order))
+        ///     .To("high-value", order => order.Amount > 10000, order => _alertService.NotifyHighValue(order))
+        ///     .To("priority", order => order.IsPriority, order => _priorityQueue.Enqueue(order)))
+        /// </code>
+        /// </example>
+        IFanOutBuilder<TIn, TCurrent> To(string name, Func<TCurrent, bool> predicate, Action<TCurrent> sinkFunction);
+
+        /// <summary>
+        /// Adds a named sink operator to the fan-out.
+        /// Use this overload when you need more control over sink lifecycle (Start/Stop).
+        /// </summary>
+        /// <param name="name">The unique name of the sink for identification and telemetry.</param>
+        /// <param name="sinkOperator">The sink operator implementation to consume data.</param>
+        /// <returns>The fan-out builder for method chaining.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="sinkOperator"/> is null.</exception>
+        /// <example>
+        /// <code>
+        /// .FanOut(fanOut => fanOut
+        ///     .To("kafka", new KafkaSinkOperator&lt;Order&gt;(kafkaConfig))
+        ///     .To("elasticsearch", new ElasticsearchSinkOperator&lt;Order&gt;(esConfig)))
+        /// </code>
+        /// </example>
+        IFanOutBuilder<TIn, TCurrent> To(string name, ISinkOperator<TCurrent> sinkOperator);
+
+        /// <summary>
+        /// Adds a named sink operator to the fan-out with a filter predicate.
+        /// Only data that matches the predicate will be sent to this sink operator.
+        /// </summary>
+        /// <param name="name">The unique name of the sink for identification and telemetry.</param>
+        /// <param name="predicate">A filter predicate that determines which data reaches this sink.</param>
+        /// <param name="sinkOperator">The sink operator implementation to consume filtered data.</param>
+        /// <returns>The fan-out builder for method chaining.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="predicate"/> or <paramref name="sinkOperator"/> is null.</exception>
+        IFanOutBuilder<TIn, TCurrent> To(string name, Func<TCurrent, bool> predicate, ISinkOperator<TCurrent> sinkOperator);
+
+        /// <summary>
+        /// Adds a named sink with a transformation before the sink.
+        /// Use this when you need to transform data differently for a specific sink.
+        /// </summary>
+        /// <typeparam name="TOutput">The type of data after transformation.</typeparam>
+        /// <param name="name">The unique name of the sink for identification and telemetry.</param>
+        /// <param name="mapFunction">A function to transform data before it reaches the sink.</param>
+        /// <param name="sinkFunction">The action to consume transformed data.</param>
+        /// <returns>The fan-out builder for method chaining.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="mapFunction"/> or <paramref name="sinkFunction"/> is null.</exception>
+        /// <example>
+        /// <code>
+        /// .FanOut(fanOut => fanOut
+        ///     .To("database", order => _repository.Save(order))
+        ///     .ToWithTransform("audit-log", 
+        ///         order => new AuditEntry(order.Id, DateTime.UtcNow, "Created"),
+        ///         audit => _auditRepository.Log(audit)))
+        /// </code>
+        /// </example>
+        IFanOutBuilder<TIn, TCurrent> ToWithTransform<TOutput>(string name, Func<TCurrent, TOutput> mapFunction, Action<TOutput> sinkFunction);
+
+        /// <summary>
+        /// Builds the stream with all configured fan-out sinks.
+        /// </summary>
+        /// <returns>The built stream instance ready to be started.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when no sinks have been configured.</exception>
+        IStream<TIn, TCurrent> Build();
+    }
+}

--- a/src/Cortex.Streams/Abstractions/IStreamBuilder.cs
+++ b/src/Cortex.Streams/Abstractions/IStreamBuilder.cs
@@ -73,6 +73,37 @@ namespace Cortex.Streams.Abstractions
         IStreamBuilder<TIn, TCurrent> AddBranch(string name, Action<IBranchStreamBuilder<TIn, TCurrent>> config);
 
         /// <summary>
+        /// Creates a fan-out pattern to send data to multiple sinks simultaneously.
+        /// Use this when you need to send the same data to multiple destinations
+        /// without intermediate transformations between sinks.
+        /// </summary>
+        /// <param name="config">An action to configure the fan-out sinks using the builder.</param>
+        /// <returns>A fan-out builder to configure and build the stream.</returns>
+        /// <remarks>
+        /// <para>
+        /// FanOut is simpler than AddBranch when you only need multiple sinks without
+        /// per-sink transformations. For complex branching with different transformations
+        /// per branch, use <see cref="AddBranch"/> instead.
+        /// </para>
+        /// <para>
+        /// Each sink can optionally have a filter predicate to receive only matching data.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// var stream = StreamBuilder&lt;Order&gt;.CreateNewStream("OrderProcessor")
+        ///     .Stream()
+        ///     .Map(order => EnrichOrder(order))
+        ///     .FanOut(fanOut => fanOut
+        ///         .To("database", order => SaveToDatabase(order))
+        ///         .To("kafka", order => PublishToKafka(order))
+        ///         .To("alerts", order => order.Amount > 10000, order => SendAlert(order)))
+        ///     .Build();
+        /// </code>
+        /// </example>
+        IFanOutBuilder<TIn, TCurrent> FanOut(Action<IFanOutBuilder<TIn, TCurrent>> config);
+
+        /// <summary>
         /// Builds the stream
         /// </summary>
         /// <returns></returns>

--- a/src/Cortex.Streams/FanOutBuilder.cs
+++ b/src/Cortex.Streams/FanOutBuilder.cs
@@ -1,0 +1,210 @@
+using Cortex.Streams.Abstractions;
+using Cortex.Streams.ErrorHandling;
+using Cortex.Streams.Operators;
+using Cortex.Streams.Performance;
+using Cortex.Telemetry;
+using System;
+using System.Collections.Generic;
+
+namespace Cortex.Streams
+{
+    /// <summary>
+    /// Builder for creating fan-out patterns with multiple sinks.
+    /// This class manages the configuration of multiple sink destinations
+    /// that receive the same data stream in parallel.
+    /// </summary>
+    /// <typeparam name="TIn">The type of the initial input to the stream.</typeparam>
+    /// <typeparam name="TCurrent">The current type of data being processed.</typeparam>
+    internal class FanOutBuilder<TIn, TCurrent> : IFanOutBuilder<TIn, TCurrent>
+    {
+        private readonly string _streamName;
+        private readonly IOperator _firstOperator;
+        private readonly IOperator _lastOperatorBeforeFanOut;
+        private readonly ForkOperator<TCurrent> _forkOperator;
+        private readonly List<BranchOperator<TCurrent>> _branchOperators;
+        private readonly HashSet<string> _sinkNames;
+        private readonly ITelemetryProvider _telemetryProvider;
+        private readonly StreamExecutionOptions _executionOptions;
+        private readonly StreamPerformanceOptions _performanceOptions;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FanOutBuilder{TIn, TCurrent}"/> class.
+        /// </summary>
+        /// <param name="streamName">The name of the stream.</param>
+        /// <param name="firstOperator">The first operator in the pipeline.</param>
+        /// <param name="lastOperatorBeforeFanOut">The last operator before the fan-out point.</param>
+        /// <param name="telemetryProvider">Optional telemetry provider for metrics and tracing.</param>
+        /// <param name="executionOptions">Stream execution options for error handling.</param>
+        /// <param name="performanceOptions">Performance tuning options.</param>
+        internal FanOutBuilder(
+            string streamName,
+            IOperator firstOperator,
+            IOperator lastOperatorBeforeFanOut,
+            ITelemetryProvider telemetryProvider,
+            StreamExecutionOptions executionOptions,
+            StreamPerformanceOptions performanceOptions)
+        {
+            _streamName = streamName ?? throw new ArgumentNullException(nameof(streamName));
+            _telemetryProvider = telemetryProvider;
+            _executionOptions = executionOptions ?? StreamExecutionOptions.Default;
+            _performanceOptions = performanceOptions ?? StreamPerformanceOptions.Default;
+
+            _forkOperator = new ForkOperator<TCurrent>();
+            _branchOperators = new List<BranchOperator<TCurrent>>();
+            _sinkNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            // Store original first operator or use fork as first
+            if (firstOperator == null)
+            {
+                _firstOperator = _forkOperator;
+                _lastOperatorBeforeFanOut = null;
+            }
+            else
+            {
+                _firstOperator = firstOperator;
+                _lastOperatorBeforeFanOut = lastOperatorBeforeFanOut;
+
+                // Connect the fork operator to the pipeline
+                if (_lastOperatorBeforeFanOut != null)
+                {
+                    _lastOperatorBeforeFanOut.SetNext(_forkOperator);
+                }
+                else
+                {
+                    // First operator is also the last, set fork as next
+                    _firstOperator.SetNext(_forkOperator);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public IFanOutBuilder<TIn, TCurrent> To(string name, Action<TCurrent> sinkFunction)
+        {
+            ValidateSinkName(name);
+            if (sinkFunction == null)
+                throw new ArgumentNullException(nameof(sinkFunction));
+
+            var sinkOperator = new SinkOperator<TCurrent>(sinkFunction);
+            AddSinkBranch(name, sinkOperator);
+
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IFanOutBuilder<TIn, TCurrent> To(string name, Func<TCurrent, bool> predicate, Action<TCurrent> sinkFunction)
+        {
+            ValidateSinkName(name);
+            if (predicate == null)
+                throw new ArgumentNullException(nameof(predicate));
+            if (sinkFunction == null)
+                throw new ArgumentNullException(nameof(sinkFunction));
+
+            // Create a mini-pipeline: Filter -> Sink
+            var filterOperator = new FilterOperator<TCurrent>(predicate);
+            var sinkOperator = new SinkOperator<TCurrent>(sinkFunction);
+            filterOperator.SetNext(sinkOperator);
+
+            AddSinkBranch(name, filterOperator);
+
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IFanOutBuilder<TIn, TCurrent> To(string name, ISinkOperator<TCurrent> sinkOperator)
+        {
+            ValidateSinkName(name);
+            if (sinkOperator == null)
+                throw new ArgumentNullException(nameof(sinkOperator));
+
+            var sinkAdapter = new SinkOperatorAdapter<TCurrent>(sinkOperator);
+            AddSinkBranch(name, sinkAdapter);
+
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IFanOutBuilder<TIn, TCurrent> To(string name, Func<TCurrent, bool> predicate, ISinkOperator<TCurrent> sinkOperator)
+        {
+            ValidateSinkName(name);
+            if (predicate == null)
+                throw new ArgumentNullException(nameof(predicate));
+            if (sinkOperator == null)
+                throw new ArgumentNullException(nameof(sinkOperator));
+
+            // Create a mini-pipeline: Filter -> SinkAdapter
+            var filterOperator = new FilterOperator<TCurrent>(predicate);
+            var sinkAdapter = new SinkOperatorAdapter<TCurrent>(sinkOperator);
+            filterOperator.SetNext(sinkAdapter);
+
+            AddSinkBranch(name, filterOperator);
+
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IFanOutBuilder<TIn, TCurrent> ToWithTransform<TOutput>(string name, Func<TCurrent, TOutput> mapFunction, Action<TOutput> sinkFunction)
+        {
+            ValidateSinkName(name);
+            if (mapFunction == null)
+                throw new ArgumentNullException(nameof(mapFunction));
+            if (sinkFunction == null)
+                throw new ArgumentNullException(nameof(sinkFunction));
+
+            // Create a mini-pipeline: Map -> Sink
+            var mapOperator = new MapOperator<TCurrent, TOutput>(mapFunction);
+            var sinkOperator = new SinkOperator<TOutput>(sinkFunction);
+            mapOperator.SetNext(sinkOperator);
+
+            // We need to create a branch that starts with the map operator
+            // Since BranchOperator<TCurrent> expects input of TCurrent, the map operator handles the conversion
+            var branchOperator = new BranchOperator<TCurrent>(name, mapOperator);
+
+            _forkOperator.AddBranch(name, branchOperator);
+            _branchOperators.Add(branchOperator);
+
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IStream<TIn, TCurrent> Build()
+        {
+            if (_branchOperators.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    "FanOut must have at least one sink configured. " +
+                    "Use .To() to add sinks before calling .Build().");
+            }
+
+            return new Stream<TIn, TCurrent>(
+                _streamName,
+                _firstOperator,
+                _branchOperators,
+                _telemetryProvider,
+                _executionOptions,
+                _performanceOptions);
+        }
+
+        /// <summary>
+        /// Validates that the sink name is valid and unique.
+        /// </summary>
+        private void ValidateSinkName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Sink name cannot be null, empty, or whitespace.", nameof(name));
+
+            if (!_sinkNames.Add(name))
+                throw new ArgumentException($"A sink with the name '{name}' has already been added. Sink names must be unique.", nameof(name));
+        }
+
+        /// <summary>
+        /// Adds a branch with the given first operator to the fork.
+        /// </summary>
+        private void AddSinkBranch(string name, IOperator firstOperator)
+        {
+            var branchOperator = new BranchOperator<TCurrent>(name, firstOperator);
+
+            _forkOperator.AddBranch(name, branchOperator);
+            _branchOperators.Add(branchOperator);
+        }
+    }
+}

--- a/src/Cortex.Streams/StreamBuilder.cs
+++ b/src/Cortex.Streams/StreamBuilder.cs
@@ -275,6 +275,44 @@ namespace Cortex.Streams
             return this;
         }
 
+        /// <summary>
+        /// Creates a fan-out pattern to send data to multiple sinks simultaneously.
+        /// </summary>
+        /// <param name="config">An action to configure the fan-out sinks.</param>
+        /// <returns>A fan-out builder to configure and build the stream.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="config"/> is null.</exception>
+        /// <remarks>
+        /// FanOut provides a simpler API than AddBranch when you need to send the same data
+        /// to multiple sinks without complex per-branch transformations.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// var stream = StreamBuilder&lt;Order&gt;.CreateNewStream("OrderProcessor")
+        ///     .Stream()
+        ///     .FanOut(fanOut => fanOut
+        ///         .To("database", order => SaveToDatabase(order))
+        ///         .To("kafka", order => PublishToKafka(order)))
+        ///     .Build();
+        /// </code>
+        /// </example>
+        public IFanOutBuilder<TIn, TCurrent> FanOut(Action<IFanOutBuilder<TIn, TCurrent>> config)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            var fanOutBuilder = new FanOutBuilder<TIn, TCurrent>(
+                _name,
+                _firstOperator,
+                _lastOperator,
+                _telemetryProvider,
+                _executionOptions,
+                _performanceOptions);
+
+            config(fanOutBuilder);
+
+            return fanOutBuilder;
+        }
+
         public IStreamBuilder<TIn, TCurrent> GroupBySilently<TKey>(Func<TCurrent, TKey> keySelector, string stateStoreName = null, States.IDataStore<TKey, List<TCurrent>> stateStore = null)
         {
             if (stateStore == null)

--- a/src/Cortex.Tests/Streams/Tests/FanOutIntegrationTests.cs
+++ b/src/Cortex.Tests/Streams/Tests/FanOutIntegrationTests.cs
@@ -1,0 +1,323 @@
+using Cortex.Streams.Operators;
+using System.Collections.Concurrent;
+
+namespace Cortex.Streams.Tests
+{
+    /// <summary>
+    /// Integration tests for the FanOut feature simulating real-world scenarios.
+    /// </summary>
+    public class FanOutIntegrationTests
+    {
+        #region E-Commerce Order Processing Scenario
+
+        [Fact]
+        public void FanOut_OrderProcessing_DistributesToMultipleDestinations()
+        {
+            // Arrange - Simulate an e-commerce order processing pipeline
+            var databaseOrders = new List<Order>();
+            var kafkaEvents = new List<OrderEvent>();
+            var highValueAlerts = new List<Order>();
+            var analyticsData = new List<OrderMetrics>();
+
+            var stream = StreamBuilder<Order>
+                .CreateNewStream("OrderProcessingPipeline")
+                .Stream()
+                .Filter(order => order.Status == OrderStatus.Confirmed)
+                .FanOut(fanOut => fanOut
+                    // Persist all confirmed orders to database
+                    .To("database", order => databaseOrders.Add(order))
+                    // Publish order events to Kafka for downstream consumers
+                    .ToWithTransform("kafka-events",
+                        order => new OrderEvent(order.Id, "OrderConfirmed", DateTime.UtcNow),
+                        evt => kafkaEvents.Add(evt))
+                    // Alert on high-value orders (> $1000)
+                    .To("high-value-alerts",
+                        order => order.TotalAmount > 1000,
+                        order => highValueAlerts.Add(order))
+                    // Send metrics for analytics
+                    .ToWithTransform("analytics",
+                        order => new OrderMetrics(order.Id, order.TotalAmount, order.Items.Length),
+                        metrics => analyticsData.Add(metrics)))
+                .Build();
+
+            stream.Start();
+
+            // Act - Process various orders
+            var order1 = new Order("ORD-001", OrderStatus.Confirmed, 500, new[] { "Item1", "Item2" });
+            var order2 = new Order("ORD-002", OrderStatus.Pending, 2000, new[] { "Item3" }); // Filtered out
+            var order3 = new Order("ORD-003", OrderStatus.Confirmed, 1500, new[] { "Item4", "Item5", "Item6" });
+            var order4 = new Order("ORD-004", OrderStatus.Confirmed, 250, new[] { "Item7" });
+
+            stream.Emit(order1);
+            stream.Emit(order2);
+            stream.Emit(order3);
+            stream.Emit(order4);
+
+            // Assert
+            Assert.Equal(3, databaseOrders.Count); // 3 confirmed orders
+            Assert.Equal(3, kafkaEvents.Count);
+            Assert.Single(highValueAlerts); // Only order3 > $1000
+            Assert.Equal("ORD-003", highValueAlerts[0].Id);
+            Assert.Equal(3, analyticsData.Count);
+            Assert.Equal(3, analyticsData[1].ItemCount); // order3 has 3 items
+        }
+
+        #endregion
+
+        #region IoT Sensor Data Scenario
+
+        [Fact]
+        public void FanOut_SensorData_RoutesToDifferentStorageByThreshold()
+        {
+            // Arrange - IoT sensor data processing
+            var allReadings = new ConcurrentBag<SensorReading>();
+            var criticalAlerts = new ConcurrentBag<SensorReading>();
+            var warningLog = new ConcurrentBag<SensorReading>();
+            var normalArchive = new ConcurrentBag<SensorReading>();
+
+            var stream = StreamBuilder<SensorReading>
+                .CreateNewStream("SensorDataPipeline")
+                .Stream()
+                .FanOut(fanOut => fanOut
+                    // Archive all readings
+                    .To("archive", reading => allReadings.Add(reading))
+                    // Critical: Temperature > 100°C
+                    .To("critical-alerts",
+                        reading => reading.Temperature > 100,
+                        reading => criticalAlerts.Add(reading))
+                    // Warning: Temperature between 80-100°C
+                    .To("warning-log",
+                        reading => reading.Temperature >= 80 && reading.Temperature <= 100,
+                        reading => warningLog.Add(reading))
+                    // Normal: Temperature < 80°C
+                    .To("normal-archive",
+                        reading => reading.Temperature < 80,
+                        reading => normalArchive.Add(reading)))
+                .Build();
+
+            stream.Start();
+
+            // Act - Emit sensor readings
+            var readings = new[]
+            {
+                new SensorReading("Sensor-1", 65.5, DateTime.UtcNow),
+                new SensorReading("Sensor-2", 85.0, DateTime.UtcNow),
+                new SensorReading("Sensor-3", 105.2, DateTime.UtcNow),
+                new SensorReading("Sensor-1", 72.0, DateTime.UtcNow),
+                new SensorReading("Sensor-2", 95.5, DateTime.UtcNow),
+            };
+
+            foreach (var reading in readings)
+            {
+                stream.Emit(reading);
+            }
+
+            // Assert
+            Assert.Equal(5, allReadings.Count);
+            Assert.Single(criticalAlerts);
+            Assert.Equal(2, warningLog.Count);
+            Assert.Equal(2, normalArchive.Count);
+        }
+
+        #endregion
+
+        #region User Activity Tracking Scenario
+
+        [Fact]
+        public void FanOut_UserActivity_SendsToMultipleAnalyticsSystems()
+        {
+            // Arrange - User activity tracking for analytics
+            var clickstreamData = new List<UserActivity>();
+            var purchaseEvents = new List<UserActivity>();
+            var searchQueries = new List<string>();
+            var sessionMetrics = new List<SessionMetric>();
+
+            var stream = StreamBuilder<UserActivity>
+                .CreateNewStream("UserActivityPipeline")
+                .Stream()
+                .FanOut(fanOut => fanOut
+                    // All clickstream to data lake
+                    .To("clickstream", activity => clickstreamData.Add(activity))
+                    // Purchase events to commerce analytics
+                    .To("purchases",
+                        activity => activity.Type == ActivityType.Purchase,
+                        activity => purchaseEvents.Add(activity))
+                    // Search queries for search optimization
+                    .To("search-queries",
+                        activity => activity.Type == ActivityType.Search,
+                        activity => searchQueries.Add(activity.Details))
+                    // Session metrics for engagement analysis
+                    .ToWithTransform("session-metrics",
+                        activity => new SessionMetric(activity.UserId, activity.SessionId, activity.Timestamp),
+                        metric => sessionMetrics.Add(metric)))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            var activities = new[]
+            {
+                new UserActivity("user-1", "sess-1", ActivityType.PageView, "Home", DateTime.UtcNow),
+                new UserActivity("user-1", "sess-1", ActivityType.Search, "laptop", DateTime.UtcNow),
+                new UserActivity("user-1", "sess-1", ActivityType.Purchase, "laptop-123", DateTime.UtcNow),
+                new UserActivity("user-2", "sess-2", ActivityType.PageView, "Products", DateTime.UtcNow),
+                new UserActivity("user-2", "sess-2", ActivityType.Search, "headphones", DateTime.UtcNow),
+            };
+
+            foreach (var activity in activities)
+            {
+                stream.Emit(activity);
+            }
+
+            // Assert
+            Assert.Equal(5, clickstreamData.Count);
+            Assert.Single(purchaseEvents);
+            Assert.Equal(2, searchQueries.Count);
+            Assert.Contains("laptop", searchQueries);
+            Assert.Contains("headphones", searchQueries);
+            Assert.Equal(5, sessionMetrics.Count);
+        }
+
+        #endregion
+
+        #region Log Aggregation Scenario
+
+        [Fact]
+        public void FanOut_LogAggregation_RoutesLogsByLevel()
+        {
+            // Arrange - Log aggregation pipeline
+            var allLogs = new List<LogEntry>();
+            var errorLogs = new List<LogEntry>();
+            var warningLogs = new List<LogEntry>();
+            var metricsData = new List<LogMetric>();
+
+            var stream = StreamBuilder<LogEntry>
+                .CreateNewStream("LogAggregationPipeline")
+                .Stream()
+                .FanOut(fanOut => fanOut
+                    // All logs to Elasticsearch
+                    .To("elasticsearch", log => allLogs.Add(log))
+                    // Errors to PagerDuty
+                    .To("pagerduty",
+                        log => log.Level == LogLevel.Error,
+                        log => errorLogs.Add(log))
+                    // Warnings to Slack
+                    .To("slack",
+                        log => log.Level == LogLevel.Warning,
+                        log => warningLogs.Add(log))
+                    // Metrics to Prometheus
+                    .ToWithTransform("prometheus",
+                        log => new LogMetric(log.Service, log.Level.ToString(), 1),
+                        metric => metricsData.Add(metric)))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            var logs = new[]
+            {
+                new LogEntry("api-gateway", LogLevel.Info, "Request received"),
+                new LogEntry("user-service", LogLevel.Error, "Database connection failed"),
+                new LogEntry("order-service", LogLevel.Warning, "High latency detected"),
+                new LogEntry("api-gateway", LogLevel.Info, "Response sent"),
+                new LogEntry("user-service", LogLevel.Error, "Retry failed"),
+            };
+
+            foreach (var log in logs)
+            {
+                stream.Emit(log);
+            }
+
+            // Assert
+            Assert.Equal(5, allLogs.Count);
+            Assert.Equal(2, errorLogs.Count);
+            Assert.Single(warningLogs);
+            Assert.Equal(5, metricsData.Count);
+        }
+
+        #endregion
+
+        #region Financial Transaction Scenario
+
+        [Fact]
+        public void FanOut_FinancialTransactions_MultipleComplianceChecks()
+        {
+            // Arrange - Financial transaction processing with compliance
+            var ledger = new List<Transaction>();
+            var fraudAlerts = new List<Transaction>();
+            var largeTransactionReports = new List<Transaction>();
+            var auditLog = new List<AuditEntry>();
+
+            var stream = StreamBuilder<Transaction>
+                .CreateNewStream("FinancialPipeline")
+                .Stream()
+                .FanOut(fanOut => fanOut
+                    // Main ledger
+                    .To("ledger", txn => ledger.Add(txn))
+                    // Fraud detection (unusual patterns)
+                    .To("fraud-detection",
+                        txn => txn.Amount > 10000 && txn.Type == TransactionType.International,
+                        txn => fraudAlerts.Add(txn))
+                    // Regulatory reporting (> $10,000)
+                    .To("regulatory-reporting",
+                        txn => txn.Amount > 10000,
+                        txn => largeTransactionReports.Add(txn))
+                    // Audit trail
+                    .ToWithTransform("audit",
+                        txn => new AuditEntry(txn.Id, "PROCESSED", DateTime.UtcNow),
+                        entry => auditLog.Add(entry)))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            var transactions = new[]
+            {
+                new Transaction("TXN-001", 500, TransactionType.Domestic),
+                new Transaction("TXN-002", 15000, TransactionType.International), // Fraud + Large
+                new Transaction("TXN-003", 25000, TransactionType.Domestic),       // Large only
+                new Transaction("TXN-004", 8000, TransactionType.International),
+            };
+
+            foreach (var txn in transactions)
+            {
+                stream.Emit(txn);
+            }
+
+            // Assert
+            Assert.Equal(4, ledger.Count);
+            Assert.Single(fraudAlerts); // Only TXN-002 (international + >10k)
+            Assert.Equal(2, largeTransactionReports.Count); // TXN-002 and TXN-003
+            Assert.Equal(4, auditLog.Count);
+        }
+
+        #endregion
+
+        #region Test Models
+
+        private record Order(string Id, OrderStatus Status, decimal TotalAmount, string[] Items);
+        private record OrderEvent(string OrderId, string EventType, DateTime Timestamp);
+        private record OrderMetrics(string OrderId, decimal Amount, int ItemCount);
+
+        private enum OrderStatus { Pending, Confirmed, Shipped, Delivered }
+
+        private record SensorReading(string SensorId, double Temperature, DateTime Timestamp);
+
+        private record UserActivity(string UserId, string SessionId, ActivityType Type, string Details, DateTime Timestamp);
+        private record SessionMetric(string UserId, string SessionId, DateTime Timestamp);
+
+        private enum ActivityType { PageView, Search, Purchase, AddToCart }
+
+        private record LogEntry(string Service, LogLevel Level, string Message);
+        private record LogMetric(string Service, string Level, int Count);
+
+        private enum LogLevel { Debug, Info, Warning, Error }
+
+        private record Transaction(string Id, decimal Amount, TransactionType Type);
+        private record AuditEntry(string TransactionId, string Status, DateTime Timestamp);
+
+        private enum TransactionType { Domestic, International }
+
+        #endregion
+    }
+}

--- a/src/Cortex.Tests/Streams/Tests/FanOutOperatorTests.cs
+++ b/src/Cortex.Tests/Streams/Tests/FanOutOperatorTests.cs
@@ -1,0 +1,389 @@
+using Cortex.Streams.Operators;
+
+namespace Cortex.Streams.Tests
+{
+    /// <summary>
+    /// Unit tests for the FanOut feature verifying individual sink operations.
+    /// </summary>
+    public class FanOutOperatorTests
+    {
+        #region Basic FanOut Tests
+
+        [Fact]
+        public void FanOut_SingleSink_ReceivesAllData()
+        {
+            // Arrange
+            var receivedData = new List<int>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestFanOutSingleSink")
+                .Stream()
+                .FanOut(fanOut => fanOut
+                    .To("sink1", x => receivedData.Add(x)))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(1);
+            stream.Emit(2);
+            stream.Emit(3);
+
+            // Assert
+            Assert.Equal(new[] { 1, 2, 3 }, receivedData);
+        }
+
+        [Fact]
+        public void FanOut_MultipleSinks_AllReceiveData()
+        {
+            // Arrange
+            var sink1Data = new List<int>();
+            var sink2Data = new List<int>();
+            var sink3Data = new List<int>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestFanOutMultipleSinks")
+                .Stream()
+                .FanOut(fanOut => fanOut
+                    .To("database", x => sink1Data.Add(x))
+                    .To("kafka", x => sink2Data.Add(x))
+                    .To("logging", x => sink3Data.Add(x)))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(10);
+            stream.Emit(20);
+
+            // Assert - All sinks should receive all data
+            Assert.Equal(new[] { 10, 20 }, sink1Data);
+            Assert.Equal(new[] { 10, 20 }, sink2Data);
+            Assert.Equal(new[] { 10, 20 }, sink3Data);
+        }
+
+        [Fact]
+        public void FanOut_WithFilter_OnlyMatchingDataReachesSink()
+        {
+            // Arrange
+            var allData = new List<int>();
+            var highValueData = new List<int>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestFanOutWithFilter")
+                .Stream()
+                .FanOut(fanOut => fanOut
+                    .To("all", x => allData.Add(x))
+                    .To("high-value", x => x > 50, x => highValueData.Add(x)))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(25);
+            stream.Emit(75);
+            stream.Emit(30);
+            stream.Emit(100);
+
+            // Assert
+            Assert.Equal(new[] { 25, 75, 30, 100 }, allData);
+            Assert.Equal(new[] { 75, 100 }, highValueData);
+        }
+
+        #endregion
+
+        #region FanOut with Transformations
+
+        [Fact]
+        public void FanOut_AfterMap_ReceivesTransformedData()
+        {
+            // Arrange
+            var receivedData = new List<int>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestFanOutAfterMap")
+                .Stream()
+                .Map(x => x * 2)
+                .FanOut(fanOut => fanOut
+                    .To("doubled", x => receivedData.Add(x)))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(5);
+            stream.Emit(10);
+
+            // Assert
+            Assert.Equal(new[] { 10, 20 }, receivedData);
+        }
+
+        [Fact]
+        public void FanOut_AfterFilter_ReceivesFilteredData()
+        {
+            // Arrange
+            var receivedData = new List<int>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestFanOutAfterFilter")
+                .Stream()
+                .Filter(x => x % 2 == 0)
+                .FanOut(fanOut => fanOut
+                    .To("even-numbers", x => receivedData.Add(x)))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(1);
+            stream.Emit(2);
+            stream.Emit(3);
+            stream.Emit(4);
+
+            // Assert
+            Assert.Equal(new[] { 2, 4 }, receivedData);
+        }
+
+        [Fact]
+        public void FanOut_WithToWithTransform_TransformsDataForSpecificSink()
+        {
+            // Arrange
+            var originalData = new List<int>();
+            var transformedData = new List<string>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestFanOutWithTransform")
+                .Stream()
+                .FanOut(fanOut => fanOut
+                    .To("original", x => originalData.Add(x))
+                    .ToWithTransform("formatted", x => $"Value: {x}", s => transformedData.Add(s)))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(42);
+            stream.Emit(100);
+
+            // Assert
+            Assert.Equal(new[] { 42, 100 }, originalData);
+            Assert.Equal(new[] { "Value: 42", "Value: 100" }, transformedData);
+        }
+
+        #endregion
+
+        #region FanOut with ISinkOperator
+
+        [Fact]
+        public void FanOut_WithSinkOperator_UsesCustomOperator()
+        {
+            // Arrange
+            var customSink = new TestSinkOperator<int>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestFanOutWithSinkOperator")
+                .Stream()
+                .FanOut(fanOut => fanOut
+                    .To("custom-sink", customSink))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(1);
+            stream.Emit(2);
+
+            // Assert
+            Assert.Equal(new[] { 1, 2 }, customSink.ReceivedData);
+        }
+
+        [Fact]
+        public void FanOut_WithFilteredSinkOperator_FiltersCorrectly()
+        {
+            // Arrange
+            var customSink = new TestSinkOperator<int>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestFanOutFilteredSinkOperator")
+                .Stream()
+                .FanOut(fanOut => fanOut
+                    .To("filtered-custom", x => x > 5, customSink))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(3);
+            stream.Emit(7);
+            stream.Emit(2);
+            stream.Emit(10);
+
+            // Assert
+            Assert.Equal(new[] { 7, 10 }, customSink.ReceivedData);
+        }
+
+        #endregion
+
+        #region Validation Tests
+
+        [Fact]
+        public void FanOut_NoSinks_ThrowsInvalidOperationException()
+        {
+            // Arrange & Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                StreamBuilder<int>
+                    .CreateNewStream("TestFanOutNoSinks")
+                    .Stream()
+                    .FanOut(fanOut => { /* No sinks added */ })
+                    .Build());
+
+            Assert.Contains("at least one sink", exception.Message);
+        }
+
+        [Fact]
+        public void FanOut_NullConfig_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var builder = StreamBuilder<int>
+                .CreateNewStream("TestFanOutNullConfig")
+                .Stream();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => builder.FanOut(null));
+        }
+
+        [Fact]
+        public void FanOut_EmptySinkName_ThrowsArgumentException()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentException>(() =>
+                StreamBuilder<int>
+                    .CreateNewStream("TestFanOutEmptyName")
+                    .Stream()
+                    .FanOut(fanOut => fanOut.To("", x => { })));
+        }
+
+        [Fact]
+        public void FanOut_NullSinkFunction_ThrowsArgumentNullException()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                StreamBuilder<int>
+                    .CreateNewStream("TestFanOutNullSink")
+                    .Stream()
+                    .FanOut(fanOut => fanOut.To("sink", (Action<int>)null)));
+        }
+
+        [Fact]
+        public void FanOut_DuplicateSinkName_ThrowsArgumentException()
+        {
+            // Arrange & Act & Assert
+            var exception = Assert.Throws<ArgumentException>(() =>
+                StreamBuilder<int>
+                    .CreateNewStream("TestFanOutDuplicateName")
+                    .Stream()
+                    .FanOut(fanOut => fanOut
+                        .To("database", x => { })
+                        .To("database", x => { })));
+
+            Assert.Contains("database", exception.Message);
+            Assert.Contains("already been added", exception.Message);
+        }
+
+        [Fact]
+        public void FanOut_NullPredicate_ThrowsArgumentNullException()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                StreamBuilder<int>
+                    .CreateNewStream("TestFanOutNullPredicate")
+                    .Stream()
+                    .FanOut(fanOut => fanOut.To("sink", null, x => { })));
+        }
+
+        #endregion
+
+        #region Complex Pipeline Tests
+
+        [Fact]
+        public void FanOut_ComplexPipeline_MapFilterFanOut()
+        {
+            // Arrange
+            var dbData = new List<string>();
+            var alertData = new List<string>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestComplexPipeline")
+                .Stream()
+                .Filter(x => x > 0)
+                .Map(x => $"Order-{x}")
+                .FanOut(fanOut => fanOut
+                    .To("database", s => dbData.Add(s))
+                    .To("alerts", s => s.Contains("100"), s => alertData.Add(s)))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(-5);   // Filtered out
+            stream.Emit(50);   // -> "Order-50" -> database only
+            stream.Emit(100);  // -> "Order-100" -> database + alerts
+
+            // Assert
+            Assert.Equal(new[] { "Order-50", "Order-100" }, dbData);
+            Assert.Equal(new[] { "Order-100" }, alertData);
+        }
+
+        [Fact]
+        public void FanOut_WithMultipleFilters_EachSinkReceivesCorrectData()
+        {
+            // Arrange
+            var lowData = new List<int>();
+            var mediumData = new List<int>();
+            var highData = new List<int>();
+
+            var stream = StreamBuilder<int>
+                .CreateNewStream("TestMultipleFilters")
+                .Stream()
+                .FanOut(fanOut => fanOut
+                    .To("low", x => x < 10, x => lowData.Add(x))
+                    .To("medium", x => x >= 10 && x < 100, x => mediumData.Add(x))
+                    .To("high", x => x >= 100, x => highData.Add(x)))
+                .Build();
+
+            stream.Start();
+
+            // Act
+            stream.Emit(5);
+            stream.Emit(50);
+            stream.Emit(500);
+            stream.Emit(8);
+            stream.Emit(75);
+
+            // Assert
+            Assert.Equal(new[] { 5, 8 }, lowData);
+            Assert.Equal(new[] { 50, 75 }, mediumData);
+            Assert.Equal(new[] { 500 }, highData);
+        }
+
+        #endregion
+
+        #region Helper Classes
+
+        /// <summary>
+        /// Test sink operator for verifying ISinkOperator integration.
+        /// </summary>
+        private class TestSinkOperator<T> : ISinkOperator<T>
+        {
+            public List<T> ReceivedData { get; } = new List<T>();
+            public bool IsStarted { get; private set; }
+            public bool IsStopped { get; private set; }
+
+            public void Start() => IsStarted = true;
+            public void Process(T input) => ReceivedData.Add(input);
+            public void Stop() => IsStopped = true;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Introduces the FanOut feature to Cortex.Streams, allowing streams to broadcast data to multiple sinks simultaneously. Adds the IFanOutBuilder interface and FanOut method to the stream builder API, supporting per-sink filtering and transformation. Includes a new FanOutBuilder implementation, comprehensive documentation, and extensive unit and integration tests covering real-world scenarios. This enables robust, flexible multi-sink stream processing with a fluent, user-friendly API.