### PR TITLE
v3/feature/220: Add non-generic PublishAsync(INotification) overload …

### DIFF
--- a/src/Cortex.Mediator/IMediator.cs
+++ b/src/Cortex.Mediator/IMediator.cs
@@ -117,5 +117,17 @@ namespace Cortex.Mediator
             TNotification notification,
             CancellationToken cancellationToken = default)
             where TNotification : INotification;
+
+        /// <summary>
+        /// Publishes a notification to all registered handlers.
+        /// The notification type is resolved at runtime, enabling scenarios where the concrete
+        /// type is not known at compile time (e.g., dispatching domain events from a collection,
+        /// deserializing events from a message bus).
+        /// </summary>
+        /// <param name="notification">The notification to publish.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        Task PublishAsync(
+            INotification notification,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Cortex.Mediator/Mediator.cs
+++ b/src/Cortex.Mediator/Mediator.cs
@@ -27,6 +27,7 @@ namespace Cortex.Mediator
         private static readonly ConcurrentDictionary<Type, MethodInfo> _sendQueryMethodCache = new();
         private static readonly ConcurrentDictionary<Type, MethodInfo> _sendVoidCommandMethodCache = new();
         private static readonly ConcurrentDictionary<Type, MethodInfo> _createStreamMethodCache = new();
+        private static readonly ConcurrentDictionary<Type, MethodInfo> _publishMethodCache = new();
 
         public Mediator(IServiceProvider serviceProvider)
         {
@@ -175,6 +176,27 @@ namespace Cortex.Mediator
             }
 
             await Task.WhenAll(tasks);
+        }
+
+        public Task PublishAsync(INotification notification, CancellationToken cancellationToken = default)
+        {
+            if (notification == null)
+                throw new ArgumentNullException(nameof(notification));
+
+            var notificationType = notification.GetType();
+
+            var method = _publishMethodCache.GetOrAdd(notificationType, type =>
+            {
+                var genericMethod = typeof(Mediator)
+                    .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                    .First(m => m.Name == nameof(PublishAsync) &&
+                                m.IsGenericMethodDefinition &&
+                                m.GetGenericArguments().Length == 1);
+
+                return genericMethod.MakeGenericMethod(type);
+            });
+
+            return (Task)method.Invoke(this, new object[] { notification, cancellationToken })!;
         }
 
         public IAsyncEnumerable<TResult> CreateStream<TQuery, TResult>(

--- a/src/Cortex.Tests/Mediator/Tests/RuntimeNotificationDispatchTests.cs
+++ b/src/Cortex.Tests/Mediator/Tests/RuntimeNotificationDispatchTests.cs
@@ -1,0 +1,307 @@
+using Cortex.Mediator;
+using Cortex.Mediator.Notifications;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cortex.Tests.Mediator.Tests
+{
+    #region Test Types for Runtime Notification Dispatch
+
+    public class OrderCreatedNotification : INotification
+    {
+        public string OrderId { get; set; } = string.Empty;
+    }
+
+    public class OrderCreatedHandler : INotificationHandler<OrderCreatedNotification>
+    {
+        private readonly List<string> _log;
+
+        public OrderCreatedHandler(List<string> log)
+        {
+            _log = log;
+        }
+
+        public Task Handle(OrderCreatedNotification notification, CancellationToken cancellationToken)
+        {
+            _log.Add($"OrderCreated: {notification.OrderId}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public class PaymentProcessedNotification : INotification
+    {
+        public string PaymentId { get; set; } = string.Empty;
+    }
+
+    public class PaymentProcessedHandler : INotificationHandler<PaymentProcessedNotification>
+    {
+        private readonly List<string> _log;
+
+        public PaymentProcessedHandler(List<string> log)
+        {
+            _log = log;
+        }
+
+        public Task Handle(PaymentProcessedNotification notification, CancellationToken cancellationToken)
+        {
+            _log.Add($"PaymentProcessed: {notification.PaymentId}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public class RuntimeNotificationPipelineBehavior<TNotification> : INotificationPipelineBehavior<TNotification>
+        where TNotification : INotification
+    {
+        private readonly List<string> _log;
+
+        public RuntimeNotificationPipelineBehavior(List<string> log)
+        {
+            _log = log;
+        }
+
+        public async Task Handle(TNotification notification, NotificationHandlerDelegate next, CancellationToken cancellationToken)
+        {
+            _log.Add($"Before: {typeof(TNotification).Name}");
+            await next();
+            _log.Add($"After: {typeof(TNotification).Name}");
+        }
+    }
+
+    #endregion
+
+    public class RuntimeNotificationDispatchTests
+    {
+        [Fact]
+        public async Task PublishAsync_NonGeneric_ShouldDispatchToCorrectHandler()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddTransient<INotificationHandler<OrderCreatedNotification>>(sp =>
+                new OrderCreatedHandler(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            INotification notification = new OrderCreatedNotification { OrderId = "ORD-001" };
+
+            // Act - use the non-generic overload
+            await mediator.PublishAsync(notification);
+
+            // Assert
+            Assert.Single(log);
+            Assert.Equal("OrderCreated: ORD-001", log[0]);
+        }
+
+        [Fact]
+        public async Task PublishAsync_NonGeneric_WithNullNotification_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                mediator.PublishAsync((INotification)null!));
+        }
+
+        [Fact]
+        public async Task PublishAsync_NonGeneric_WithMultipleHandlers_ShouldDispatchToAll()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddTransient<INotificationHandler<OrderCreatedNotification>>(sp =>
+                new OrderCreatedHandler(log));
+            // Register a second handler for the same notification
+            services.AddTransient<INotificationHandler<OrderCreatedNotification>>(sp =>
+                new OrderCreatedHandler(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            INotification notification = new OrderCreatedNotification { OrderId = "ORD-002" };
+
+            // Act
+            await mediator.PublishAsync(notification);
+
+            // Assert
+            Assert.Equal(2, log.Count);
+            Assert.All(log, entry => Assert.Equal("OrderCreated: ORD-002", entry));
+        }
+
+        [Fact]
+        public async Task PublishAsync_NonGeneric_WithNoHandlers_ShouldCompleteSuccessfully()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            INotification notification = new OrderCreatedNotification { OrderId = "ORD-003" };
+
+            // Act & Assert - should not throw
+            await mediator.PublishAsync(notification);
+        }
+
+        [Fact]
+        public async Task PublishAsync_NonGeneric_WithPipelineBehavior_ShouldExecuteBehavior()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddTransient<INotificationHandler<OrderCreatedNotification>>(sp =>
+                new OrderCreatedHandler(log));
+            services.AddTransient<INotificationPipelineBehavior<OrderCreatedNotification>>(sp =>
+                new RuntimeNotificationPipelineBehavior<OrderCreatedNotification>(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            INotification notification = new OrderCreatedNotification { OrderId = "ORD-004" };
+
+            // Act
+            await mediator.PublishAsync(notification);
+
+            // Assert
+            Assert.Equal(3, log.Count);
+            Assert.Equal("Before: OrderCreatedNotification", log[0]);
+            Assert.Equal("OrderCreated: ORD-004", log[1]);
+            Assert.Equal("After: OrderCreatedNotification", log[2]);
+        }
+
+        [Fact]
+        public async Task PublishAsync_NonGeneric_ShouldPassCancellationToken()
+        {
+            // Arrange
+            var cts = new CancellationTokenSource();
+            CancellationToken capturedToken = default;
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddTransient<INotificationHandler<OrderCreatedNotification>>(sp =>
+                new DelegateNotificationHandler<OrderCreatedNotification>((n, ct) =>
+                {
+                    capturedToken = ct;
+                    return Task.CompletedTask;
+                }));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            INotification notification = new OrderCreatedNotification { OrderId = "ORD-005" };
+
+            // Act
+            await mediator.PublishAsync(notification, cts.Token);
+
+            // Assert
+            Assert.Equal(cts.Token, capturedToken);
+        }
+
+        [Fact]
+        public async Task PublishAsync_NonGeneric_DomainEventsScenario_ShouldDispatchMultipleTypes()
+        {
+            // Arrange - simulates an aggregate root with mixed domain events
+            var log = new List<string>();
+            var services = new ServiceCollection();
+
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddTransient<INotificationHandler<OrderCreatedNotification>>(sp =>
+                new OrderCreatedHandler(log));
+            services.AddTransient<INotificationHandler<PaymentProcessedNotification>>(sp =>
+                new PaymentProcessedHandler(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Simulate domain events list from an aggregate root
+            var domainEvents = new List<INotification>
+            {
+                new OrderCreatedNotification { OrderId = "ORD-100" },
+                new PaymentProcessedNotification { PaymentId = "PAY-200" },
+                new OrderCreatedNotification { OrderId = "ORD-101" }
+            };
+
+            // Act - dispatch all events using the non-generic overload
+            foreach (var domainEvent in domainEvents)
+            {
+                await mediator.PublishAsync(domainEvent);
+            }
+
+            // Assert
+            Assert.Equal(3, log.Count);
+            Assert.Equal("OrderCreated: ORD-100", log[0]);
+            Assert.Equal("PaymentProcessed: PAY-200", log[1]);
+            Assert.Equal("OrderCreated: ORD-101", log[2]);
+        }
+
+        [Fact]
+        public async Task PublishAsync_NonGeneric_ShouldProduceSameResultAsGenericOverload()
+        {
+            // Arrange
+            var genericLog = new List<string>();
+            var runtimeLog = new List<string>();
+
+            // Build two identical service providers
+            ServiceProvider BuildProvider(List<string> log)
+            {
+                var services = new ServiceCollection();
+                services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+                services.AddTransient<INotificationHandler<OrderCreatedNotification>>(sp =>
+                    new OrderCreatedHandler(log));
+                services.AddTransient<INotificationPipelineBehavior<OrderCreatedNotification>>(sp =>
+                    new RuntimeNotificationPipelineBehavior<OrderCreatedNotification>(log));
+                return services.BuildServiceProvider();
+            }
+
+            var genericProvider = BuildProvider(genericLog);
+            var runtimeProvider = BuildProvider(runtimeLog);
+
+            var notification = new OrderCreatedNotification { OrderId = "ORD-COMPARE" };
+
+            // Act - generic overload
+            var genericMediator = genericProvider.GetRequiredService<IMediator>();
+            await genericMediator.PublishAsync(notification);
+
+            // Act - non-generic overload
+            var runtimeMediator = runtimeProvider.GetRequiredService<IMediator>();
+            await runtimeMediator.PublishAsync((INotification)notification);
+
+            // Assert - both should produce identical logs
+            Assert.Equal(genericLog.Count, runtimeLog.Count);
+            for (int i = 0; i < genericLog.Count; i++)
+            {
+                Assert.Equal(genericLog[i], runtimeLog[i]);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Helper handler that delegates to a provided function, useful for capturing arguments in tests.
+    /// </summary>
+    internal class DelegateNotificationHandler<TNotification> : INotificationHandler<TNotification>
+        where TNotification : INotification
+    {
+        private readonly Func<TNotification, CancellationToken, Task> _handler;
+
+        public DelegateNotificationHandler(Func<TNotification, CancellationToken, Task> handler)
+        {
+            _handler = handler;
+        }
+
+        public Task Handle(TNotification notification, CancellationToken cancellationToken)
+        {
+            return _handler(notification, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
…for runtime-typed notification dispatch

Enables publishing notifications when the concrete type is only known at runtime, such as dispatching domain events from a List<INotification> or deserializing events from a message bus. Follows the same reflection + ConcurrentDictionary caching pattern used by SendCommandAsync and SendQueryAsync.