### PR TITLE
v3/feature/215: Pluggable Notification Publish Strategies

### DIFF
--- a/src/Cortex.Mediator/DependencyInjection/MediatorOptions.cs
+++ b/src/Cortex.Mediator/DependencyInjection/MediatorOptions.cs
@@ -26,6 +26,29 @@ namespace Cortex.Mediator.DependencyInjection
         /// </summary>
         public ServiceLifetime HandlerLifetime { get; set; } = ServiceLifetime.Scoped;
 
+        /// <summary>
+        /// Gets the type of notification publish strategy to use.
+        /// Defaults to <see cref="ParallelNotificationStrategy"/>.
+        /// Use <see cref="UseNotificationPublishStrategy{TStrategy}"/> to change.
+        /// </summary>
+        internal Type NotificationPublishStrategyType { get; private set; } = typeof(ParallelNotificationStrategy);
+
+        /// <summary>
+        /// Sets the strategy used to publish notifications to multiple handlers.
+        /// </summary>
+        /// <typeparam name="TStrategy">
+        /// The strategy implementation. Built-in options:
+        /// <see cref="ParallelNotificationStrategy"/> (default) — all handlers run in parallel via Task.WhenAll,
+        /// <see cref="SequentialNotificationStrategy"/> — handlers run one at a time in registration order,
+        /// <see cref="StopOnFirstFailureNotificationStrategy"/> — sequential, stops on first exception.
+        /// </typeparam>
+        public MediatorOptions UseNotificationPublishStrategy<TStrategy>()
+            where TStrategy : class, INotificationPublishStrategy
+        {
+            NotificationPublishStrategyType = typeof(TStrategy);
+            return this;
+        }
+
 
         /// <summary>
         /// Register a *closed* command pipeline behavior.

--- a/src/Cortex.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Cortex.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ namespace Cortex.Mediator.DependencyInjection
             configure?.Invoke(options);
 
             services.AddScoped<IMediator, Mediator>();
+            services.AddSingleton(typeof(INotificationPublishStrategy), options.NotificationPublishStrategyType);
 
             // Validation has been removed for issue #118
             //services.AddValidatorsFromAssemblies(handlerAssemblyMarkerTypes.Select(t => t.Assembly));

--- a/src/Cortex.Mediator/Mediator.cs
+++ b/src/Cortex.Mediator/Mediator.cs
@@ -148,20 +148,19 @@ namespace Cortex.Mediator
             var behaviors = _serviceProvider.GetServices<INotificationPipelineBehavior<TNotification>>();
 
             // Materialize behaviors once since we need to iterate multiple times
-            // Use stackalloc-friendly pattern for small counts
             var behaviorList = behaviors as INotificationPipelineBehavior<TNotification>[] ?? behaviors.ToArray();
             Array.Reverse(behaviorList);
 
-            // Count handlers to pre-allocate task array
+            // Count handlers to pre-allocate delegate list
             var handlerList = handlers as INotificationHandler<TNotification>[] ?? handlers.ToArray();
             if (handlerList.Length == 0)
                 return;
 
-            var tasks = new Task[handlerList.Length];
+            // Build a pipeline delegate for each handler
+            var handlerDelegates = new Func<Task>[handlerList.Length];
             for (int i = 0; i < handlerList.Length; i++)
             {
                 var handler = handlerList[i];
-                // Build the pipeline for this specific handler
                 NotificationHandlerDelegate handlerDelegate = () => handler.Handle(notification, cancellationToken);
 
                 // Wrap the handler with all behaviors (already reversed)
@@ -172,10 +171,21 @@ namespace Cortex.Mediator
                     handlerDelegate = () => currentBehavior.Handle(notification, currentDelegate, cancellationToken);
                 }
 
-                tasks[i] = handlerDelegate();
+                var finalDelegate = handlerDelegate;
+                handlerDelegates[i] = () => finalDelegate();
             }
 
-            await Task.WhenAll(tasks);
+            // Delegate to the publish strategy
+            var strategy = _serviceProvider.GetService<INotificationPublishStrategy>();
+            if (strategy != null)
+            {
+                await strategy.PublishAsync(handlerDelegates, cancellationToken);
+            }
+            else
+            {
+                // Fallback to parallel when no strategy is registered (e.g., manual DI without AddCortexMediator)
+                await Task.WhenAll(handlerDelegates.Select(d => d()));
+            }
         }
 
         public Task PublishAsync(INotification notification, CancellationToken cancellationToken = default)

--- a/src/Cortex.Mediator/Notifications/INotificationPublishStrategy.cs
+++ b/src/Cortex.Mediator/Notifications/INotificationPublishStrategy.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cortex.Mediator.Notifications
+{
+    /// <summary>
+    /// Defines the strategy for publishing notifications to multiple handler pipelines.
+    /// </summary>
+    public interface INotificationPublishStrategy
+    {
+        /// <summary>
+        /// Publishes a notification by executing the provided handler delegates according to the strategy.
+        /// </summary>
+        /// <param name="handlerDelegates">The handler pipeline delegates to execute.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        Task PublishAsync(
+            IEnumerable<Func<Task>> handlerDelegates,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/Cortex.Mediator/Notifications/ParallelNotificationStrategy.cs
+++ b/src/Cortex.Mediator/Notifications/ParallelNotificationStrategy.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cortex.Mediator.Notifications
+{
+    /// <summary>
+    /// Publishes notifications to all handlers in parallel using Task.WhenAll.
+    /// This is the default strategy.
+    /// </summary>
+    public sealed class ParallelNotificationStrategy : INotificationPublishStrategy
+    {
+        public Task PublishAsync(
+            IEnumerable<Func<Task>> handlerDelegates,
+            CancellationToken cancellationToken)
+        {
+            var tasks = handlerDelegates.Select(handler => handler()).ToArray();
+
+            if (tasks.Length == 0)
+                return Task.CompletedTask;
+
+            return Task.WhenAll(tasks);
+        }
+    }
+}

--- a/src/Cortex.Mediator/Notifications/SequentialNotificationStrategy.cs
+++ b/src/Cortex.Mediator/Notifications/SequentialNotificationStrategy.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cortex.Mediator.Notifications
+{
+    /// <summary>
+    /// Publishes notifications to handlers one at a time in registration order.
+    /// If a handler throws, the exception propagates and remaining handlers are not executed.
+    /// </summary>
+    public sealed class SequentialNotificationStrategy : INotificationPublishStrategy
+    {
+        public async Task PublishAsync(
+            IEnumerable<Func<Task>> handlerDelegates,
+            CancellationToken cancellationToken)
+        {
+            foreach (var handler in handlerDelegates)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await handler();
+            }
+        }
+    }
+}

--- a/src/Cortex.Mediator/Notifications/StopOnFirstFailureNotificationStrategy.cs
+++ b/src/Cortex.Mediator/Notifications/StopOnFirstFailureNotificationStrategy.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cortex.Mediator.Notifications
+{
+    /// <summary>
+    /// Publishes notifications to handlers sequentially, stopping immediately on the first exception.
+    /// Unlike <see cref="SequentialNotificationStrategy"/>, this strategy explicitly signals that
+    /// failure handling is the primary concern — remaining handlers are intentionally skipped.
+    /// </summary>
+    public sealed class StopOnFirstFailureNotificationStrategy : INotificationPublishStrategy
+    {
+        public async Task PublishAsync(
+            IEnumerable<Func<Task>> handlerDelegates,
+            CancellationToken cancellationToken)
+        {
+            foreach (var handler in handlerDelegates)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await handler();
+            }
+        }
+    }
+}

--- a/src/Cortex.Tests/Mediator/Tests/NotificationPublishStrategyTests.cs
+++ b/src/Cortex.Tests/Mediator/Tests/NotificationPublishStrategyTests.cs
@@ -1,0 +1,427 @@
+using Cortex.Mediator;
+using Cortex.Mediator.DependencyInjection;
+using Cortex.Mediator.Notifications;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cortex.Tests.Mediator.Tests
+{
+    #region Test Types for Notification Publish Strategy Tests
+
+    public class StrategyTestNotification : INotification
+    {
+        public string Message { get; set; } = string.Empty;
+    }
+
+    public class StrategyTestHandler1 : INotificationHandler<StrategyTestNotification>
+    {
+        private readonly List<string> _log;
+
+        public StrategyTestHandler1(List<string> log)
+        {
+            _log = log;
+        }
+
+        public Task Handle(StrategyTestNotification notification, CancellationToken cancellationToken)
+        {
+            _log.Add($"Handler1: {notification.Message}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public class StrategyTestHandler2 : INotificationHandler<StrategyTestNotification>
+    {
+        private readonly List<string> _log;
+
+        public StrategyTestHandler2(List<string> log)
+        {
+            _log = log;
+        }
+
+        public Task Handle(StrategyTestNotification notification, CancellationToken cancellationToken)
+        {
+            _log.Add($"Handler2: {notification.Message}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public class ThrowingStrategyHandler : INotificationHandler<StrategyTestNotification>
+    {
+        private readonly List<string> _log;
+
+        public ThrowingStrategyHandler(List<string> log)
+        {
+            _log = log;
+        }
+
+        public Task Handle(StrategyTestNotification notification, CancellationToken cancellationToken)
+        {
+            _log.Add("ThrowingHandler: Before throw");
+            throw new InvalidOperationException("Handler failed");
+        }
+    }
+
+    #endregion
+
+    public class NotificationPublishStrategyTests
+    {
+        #region MediatorOptions Tests
+
+        [Fact]
+        public void DefaultStrategy_ShouldBeParallel()
+        {
+            // Arrange & Act
+            var options = new MediatorOptions();
+
+            // Assert - verify default through DI registration
+            var services = new ServiceCollection();
+            services.AddCortexMediator(new Type[0], _ => { });
+            var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(INotificationPublishStrategy));
+
+            Assert.NotNull(descriptor);
+            Assert.Equal(typeof(ParallelNotificationStrategy), descriptor!.ImplementationType);
+        }
+
+        [Fact]
+        public void UseNotificationPublishStrategy_ShouldRegisterCustomStrategy()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddCortexMediator(new Type[0], options =>
+            {
+                options.UseNotificationPublishStrategy<SequentialNotificationStrategy>();
+            });
+
+            // Assert
+            var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(INotificationPublishStrategy));
+            Assert.NotNull(descriptor);
+            Assert.Equal(typeof(SequentialNotificationStrategy), descriptor!.ImplementationType);
+        }
+
+        [Fact]
+        public void UseNotificationPublishStrategy_ShouldReturnOptionsForFluent()
+        {
+            // Arrange
+            var options = new MediatorOptions();
+
+            // Act
+            var result = options.UseNotificationPublishStrategy<SequentialNotificationStrategy>();
+
+            // Assert
+            Assert.Same(options, result);
+        }
+
+        #endregion
+
+        #region ParallelNotificationStrategy Tests
+
+        [Fact]
+        public async Task ParallelStrategy_ShouldExecuteAllHandlers()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = BuildServices(log);
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.PublishAsync(new StrategyTestNotification { Message = "Parallel" });
+
+            // Assert
+            Assert.Contains("Handler1: Parallel", log);
+            Assert.Contains("Handler2: Parallel", log);
+        }
+
+        [Fact]
+        public async Task ParallelStrategy_WithThrowingHandler_ShouldPropagateException()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddSingleton<INotificationPublishStrategy, ParallelNotificationStrategy>();
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new ThrowingStrategyHandler(log));
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler1(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                mediator.PublishAsync(new StrategyTestNotification { Message = "Fail" }));
+        }
+
+        #endregion
+
+        #region SequentialNotificationStrategy Tests
+
+        [Fact]
+        public async Task SequentialStrategy_ShouldExecuteHandlersInOrder()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = BuildServices(log, strategyType: typeof(SequentialNotificationStrategy));
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.PublishAsync(new StrategyTestNotification { Message = "Sequential" });
+
+            // Assert - sequential guarantees order matches registration order
+            Assert.Equal(2, log.Count);
+            Assert.Equal("Handler1: Sequential", log[0]);
+            Assert.Equal("Handler2: Sequential", log[1]);
+        }
+
+        [Fact]
+        public async Task SequentialStrategy_WithThrowingHandler_ShouldStopAndPropagate()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddSingleton<INotificationPublishStrategy, SequentialNotificationStrategy>();
+            // Throwing handler is first
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new ThrowingStrategyHandler(log));
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler1(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                mediator.PublishAsync(new StrategyTestNotification { Message = "Fail" }));
+
+            // Second handler should NOT have executed
+            Assert.DoesNotContain("Handler1: Fail", log);
+            Assert.Contains("ThrowingHandler: Before throw", log);
+        }
+
+        [Fact]
+        public async Task SequentialStrategy_WithCancellation_ShouldStopBetweenHandlers()
+        {
+            // Arrange
+            var log = new List<string>();
+            var cts = new CancellationTokenSource();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddSingleton<INotificationPublishStrategy, SequentialNotificationStrategy>();
+            // First handler cancels the token
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new CancellingHandler(log, cts));
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler1(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                mediator.PublishAsync(new StrategyTestNotification { Message = "Cancel" }, cts.Token));
+
+            // First handler executed, second should not
+            Assert.Contains("Cancelling: Cancel", log);
+            Assert.DoesNotContain("Handler1: Cancel", log);
+        }
+
+        #endregion
+
+        #region StopOnFirstFailureNotificationStrategy Tests
+
+        [Fact]
+        public async Task StopOnFirstFailureStrategy_ShouldExecuteAllWhenNoFailure()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = BuildServices(log, strategyType: typeof(StopOnFirstFailureNotificationStrategy));
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.PublishAsync(new StrategyTestNotification { Message = "NoFail" });
+
+            // Assert
+            Assert.Equal(2, log.Count);
+            Assert.Equal("Handler1: NoFail", log[0]);
+            Assert.Equal("Handler2: NoFail", log[1]);
+        }
+
+        [Fact]
+        public async Task StopOnFirstFailureStrategy_ShouldStopOnFirstException()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddSingleton<INotificationPublishStrategy, StopOnFirstFailureNotificationStrategy>();
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler1(log));
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new ThrowingStrategyHandler(log));
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler2(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                mediator.PublishAsync(new StrategyTestNotification { Message = "StopOnFail" }));
+
+            // First handler ran, throwing handler ran, third handler should NOT
+            Assert.Contains("Handler1: StopOnFail", log);
+            Assert.Contains("ThrowingHandler: Before throw", log);
+            Assert.DoesNotContain("Handler2: StopOnFail", log);
+        }
+
+        #endregion
+
+        #region Integration with AddCortexMediator
+
+        [Fact]
+        public async Task AddCortexMediator_WithSequentialStrategy_ShouldUseIt()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddCortexMediator(new Type[0], options =>
+            {
+                options.UseNotificationPublishStrategy<SequentialNotificationStrategy>();
+            });
+
+            // Register handlers manually (not via assembly scanning)
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler1(log));
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler2(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.PublishAsync(new StrategyTestNotification { Message = "DI" });
+
+            // Assert - sequential preserves order
+            Assert.Equal(2, log.Count);
+            Assert.Equal("Handler1: DI", log[0]);
+            Assert.Equal("Handler2: DI", log[1]);
+        }
+
+        [Fact]
+        public async Task Mediator_WithoutStrategyRegistered_ShouldFallbackToParallel()
+        {
+            // Arrange - manual DI without AddCortexMediator, no strategy registered
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler1(log));
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler2(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act - should not throw and should execute all handlers
+            await mediator.PublishAsync(new StrategyTestNotification { Message = "Fallback" });
+
+            // Assert
+            Assert.Contains("Handler1: Fallback", log);
+            Assert.Contains("Handler2: Fallback", log);
+        }
+
+        #endregion
+
+        #region Custom Strategy Tests
+
+        [Fact]
+        public async Task CustomStrategy_ShouldBeUsable()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddSingleton<INotificationPublishStrategy>(new ReverseOrderStrategy());
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler1(log));
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler2(log));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.PublishAsync(new StrategyTestNotification { Message = "Reverse" });
+
+            // Assert - custom strategy reverses the order
+            Assert.Equal(2, log.Count);
+            Assert.Equal("Handler2: Reverse", log[0]);
+            Assert.Equal("Handler1: Reverse", log[1]);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static ServiceCollection BuildServices(List<string> log, Type strategyType = null)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IMediator, Cortex.Mediator.Mediator>();
+            services.AddSingleton(typeof(INotificationPublishStrategy),
+                strategyType ?? typeof(ParallelNotificationStrategy));
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler1(log));
+            services.AddTransient<INotificationHandler<StrategyTestNotification>>(sp =>
+                new StrategyTestHandler2(log));
+            return services;
+        }
+
+        #endregion
+    }
+
+    #region Additional Test Handlers
+
+    internal class CancellingHandler : INotificationHandler<StrategyTestNotification>
+    {
+        private readonly List<string> _log;
+        private readonly CancellationTokenSource _cts;
+
+        public CancellingHandler(List<string> log, CancellationTokenSource cts)
+        {
+            _log = log;
+            _cts = cts;
+        }
+
+        public Task Handle(StrategyTestNotification notification, CancellationToken cancellationToken)
+        {
+            _log.Add($"Cancelling: {notification.Message}");
+            _cts.Cancel();
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Custom strategy that executes handlers in reverse order — used to verify custom strategies work.
+    /// </summary>
+    internal class ReverseOrderStrategy : INotificationPublishStrategy
+    {
+        public async Task PublishAsync(
+            IEnumerable<Func<Task>> handlerDelegates,
+            CancellationToken cancellationToken)
+        {
+            var delegates = handlerDelegates.Reverse().ToList();
+            foreach (var handler in delegates)
+            {
+                await handler();
+            }
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
  Changes

  New files:

  - Notifications/INotificationPublishStrategy.cs — Interface with a single PublishAsync(IEnumerable<Func<Task>>, CancellationToken) method. Strategies receive pre-built handler pipeline delegates and decide how to execute them.
  - Notifications/ParallelNotificationStrategy.cs — Default strategy. Executes all handlers in parallel via Task.WhenAll (preserves current behavior).
  - Notifications/SequentialNotificationStrategy.cs — Executes handlers one at a time in registration order. Respects cancellation between handlers.
  - Notifications/StopOnFirstFailureNotificationStrategy.cs — Sequential execution that stops immediately on first exception, skipping remaining handlers.

  Modified files:

  - MediatorOptions.cs — Added NotificationPublishStrategyType (internal) and UseNotificationPublishStrategy<TStrategy>() fluent method. Default is ParallelNotificationStrategy.
  - ServiceCollectionExtensions.cs — Registers INotificationPublishStrategy as singleton from the configured type.
  - Mediator.cs — Refactored PublishAsync<TNotification> to build Func<Task>[] delegates and delegate execution to INotificationPublishStrategy. Falls back to parallel when no strategy is registered (backward compatible for manual DI).

  Tests — NotificationPublishStrategyTests.cs (13 tests):
  - Default strategy is Parallel
  - UseNotificationPublishStrategy DI registration
  - Fluent API returns options
  - Parallel: all handlers execute, exceptions propagate
  - Sequential: order preserved, stops on exception, respects cancellation
  - StopOnFirstFailure: all succeed case, stops on first exception
  - Integration with AddCortexMediator
  - Fallback when no strategy registered
  - Custom strategy support (reverse order strategy)