### PR TITLE
v3/feature/225: Add explicit ordering for pipeline behaviors

### DIFF
--- a/src/Cortex.Mediator/DependencyInjection/MediatorOptions.cs
+++ b/src/Cortex.Mediator/DependencyInjection/MediatorOptions.cs
@@ -11,11 +11,11 @@ namespace Cortex.Mediator.DependencyInjection
 {
     public class MediatorOptions
     {
-        internal List<Type> CommandBehaviors { get; } = new();
-        internal List<Type> VoidCommandBehaviors { get; } = new();
-        internal List<Type> QueryBehaviors { get; } = new();
-        internal List<Type> NotificationBehaviors { get; } = new();
-        internal List<Type> StreamQueryBehaviors { get; } = new();
+        internal List<(Type BehaviorType, int Order)> CommandBehaviors { get; } = new();
+        internal List<(Type BehaviorType, int Order)> VoidCommandBehaviors { get; } = new();
+        internal List<(Type BehaviorType, int Order)> QueryBehaviors { get; } = new();
+        internal List<(Type BehaviorType, int Order)> NotificationBehaviors { get; } = new();
+        internal List<(Type BehaviorType, int Order)> StreamQueryBehaviors { get; } = new();
 
         public bool OnlyPublicClasses { get; set; } = true;
 
@@ -53,7 +53,11 @@ namespace Cortex.Mediator.DependencyInjection
         /// <summary>
         /// Register a *closed* command pipeline behavior.
         /// </summary>
-        public MediatorOptions AddCommandPipelineBehavior<TBehavior>()
+        /// <param name="order">
+        /// Execution order. Lower values run first (outermost in the pipeline).
+        /// Behaviors with the same order preserve registration order. Defaults to 0.
+        /// </param>
+        public MediatorOptions AddCommandPipelineBehavior<TBehavior>(int order = 0)
             where TBehavior : class // Add constraint
         {
             var behaviorType = typeof(TBehavior);
@@ -73,10 +77,10 @@ namespace Cortex.Mediator.DependencyInjection
                 throw new ArgumentException("Type must implement ICommandPipelineBehavior<,> or ICommandPipelineBehavior<>");
 
             if (implementsReturning)
-                CommandBehaviors.Add(behaviorType);
+                CommandBehaviors.Add((behaviorType, order));
 
             if (implementsNonReturning)
-                VoidCommandBehaviors.Add(behaviorType);
+                VoidCommandBehaviors.Add((behaviorType, order));
 
             return this;
         }
@@ -84,7 +88,12 @@ namespace Cortex.Mediator.DependencyInjection
         /// <summary>
         /// Register an *open generic* command pipeline behavior, e.g. typeof(LoggingCommandBehavior&lt;,&gt;).
         /// </summary>
-        public MediatorOptions AddOpenCommandPipelineBehavior(Type openGenericBehaviorType)
+        /// <param name="openGenericBehaviorType">The open generic behavior type.</param>
+        /// <param name="order">
+        /// Execution order. Lower values run first (outermost in the pipeline).
+        /// Behaviors with the same order preserve registration order. Defaults to 0.
+        /// </param>
+        public MediatorOptions AddOpenCommandPipelineBehavior(Type openGenericBehaviorType, int order = 0)
         {
             if (!openGenericBehaviorType.IsGenericTypeDefinition)
                 throw new ArgumentException("Type must be an open generic type definition");
@@ -101,10 +110,10 @@ namespace Cortex.Mediator.DependencyInjection
                 throw new ArgumentException("Type must implement ICommandPipelineBehavior<,> or ICommandPipelineBehavior<>");
 
             if (implementsReturning)
-                CommandBehaviors.Add(openGenericBehaviorType);
+                CommandBehaviors.Add((openGenericBehaviorType, order));
 
             if (implementsNonReturning)
-                VoidCommandBehaviors.Add(openGenericBehaviorType);
+                VoidCommandBehaviors.Add((openGenericBehaviorType, order));
 
             return this;
         }
@@ -112,7 +121,11 @@ namespace Cortex.Mediator.DependencyInjection
         /// <summary>
         /// Register a *closed* query pipeline behavior.
         /// </summary>
-        public MediatorOptions AddQueryPipelineBehavior<TBehavior>()
+        /// <param name="order">
+        /// Execution order. Lower values run first (outermost in the pipeline).
+        /// Behaviors with the same order preserve registration order. Defaults to 0.
+        /// </param>
+        public MediatorOptions AddQueryPipelineBehavior<TBehavior>(int order = 0)
             where TBehavior : class
         {
             var behaviorType = typeof(TBehavior);
@@ -127,14 +140,19 @@ namespace Cortex.Mediator.DependencyInjection
             if (!implementsQueryBehavior)
                 throw new ArgumentException("Type must implement IQueryPipelineBehavior<,>");
 
-            QueryBehaviors.Add(behaviorType);
+            QueryBehaviors.Add((behaviorType, order));
             return this;
         }
 
         /// <summary>
         /// Register an *open generic* query pipeline behavior, e.g. typeof(CachingQueryBehavior&lt;,&gt;).
         /// </summary>
-        public MediatorOptions AddOpenQueryPipelineBehavior(Type openGenericBehaviorType)
+        /// <param name="openGenericBehaviorType">The open generic behavior type.</param>
+        /// <param name="order">
+        /// Execution order. Lower values run first (outermost in the pipeline).
+        /// Behaviors with the same order preserve registration order. Defaults to 0.
+        /// </param>
+        public MediatorOptions AddOpenQueryPipelineBehavior(Type openGenericBehaviorType, int order = 0)
         {
             if (!openGenericBehaviorType.IsGenericTypeDefinition)
             {
@@ -150,14 +168,18 @@ namespace Cortex.Mediator.DependencyInjection
                 throw new ArgumentException("Type must implement IQueryPipelineBehavior<,>");
             }
 
-            QueryBehaviors.Add(openGenericBehaviorType);
+            QueryBehaviors.Add((openGenericBehaviorType, order));
             return this;
         }
 
         /// <summary>
         /// Register a *closed* notification pipeline behavior.
         /// </summary>
-        public MediatorOptions AddNotificationPipelineBehavior<TBehavior>()
+        /// <param name="order">
+        /// Execution order. Lower values run first (outermost in the pipeline).
+        /// Behaviors with the same order preserve registration order. Defaults to 0.
+        /// </param>
+        public MediatorOptions AddNotificationPipelineBehavior<TBehavior>(int order = 0)
             where TBehavior : class
         {
             var behaviorType = typeof(TBehavior);
@@ -172,14 +194,19 @@ namespace Cortex.Mediator.DependencyInjection
             if (!implementsNotificationBehavior)
                 throw new ArgumentException("Type must implement INotificationPipelineBehavior<>");
 
-            NotificationBehaviors.Add(behaviorType);
+            NotificationBehaviors.Add((behaviorType, order));
             return this;
         }
 
         /// <summary>
         /// Register an *open generic* notification pipeline behavior, e.g. typeof(LoggingNotificationBehavior&lt;&gt;).
         /// </summary>
-        public MediatorOptions AddOpenNotificationPipelineBehavior(Type openGenericBehaviorType)
+        /// <param name="openGenericBehaviorType">The open generic behavior type.</param>
+        /// <param name="order">
+        /// Execution order. Lower values run first (outermost in the pipeline).
+        /// Behaviors with the same order preserve registration order. Defaults to 0.
+        /// </param>
+        public MediatorOptions AddOpenNotificationPipelineBehavior(Type openGenericBehaviorType, int order = 0)
         {
             if (!openGenericBehaviorType.IsGenericTypeDefinition)
             {
@@ -195,14 +222,19 @@ namespace Cortex.Mediator.DependencyInjection
                 throw new ArgumentException("Type must implement INotificationPipelineBehavior<>");
             }
 
-            NotificationBehaviors.Add(openGenericBehaviorType);
+            NotificationBehaviors.Add((openGenericBehaviorType, order));
             return this;
         }
 
         /// <summary>
         /// Register an *open generic* streaming query pipeline behavior, e.g. typeof(LoggingStreamQueryBehavior&lt;,&gt;).
         /// </summary>
-        public MediatorOptions AddOpenStreamQueryPipelineBehavior(Type openGenericBehaviorType)
+        /// <param name="openGenericBehaviorType">The open generic behavior type.</param>
+        /// <param name="order">
+        /// Execution order. Lower values run first (outermost in the pipeline).
+        /// Behaviors with the same order preserve registration order. Defaults to 0.
+        /// </param>
+        public MediatorOptions AddOpenStreamQueryPipelineBehavior(Type openGenericBehaviorType, int order = 0)
         {
             if (!openGenericBehaviorType.IsGenericTypeDefinition)
             {
@@ -218,7 +250,7 @@ namespace Cortex.Mediator.DependencyInjection
                 throw new ArgumentException("Type must implement IStreamQueryPipelineBehavior<,>");
             }
 
-            StreamQueryBehaviors.Add(openGenericBehaviorType);
+            StreamQueryBehaviors.Add((openGenericBehaviorType, order));
             return this;
         }
     }

--- a/src/Cortex.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Cortex.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
@@ -116,20 +116,23 @@ namespace Cortex.Mediator.DependencyInjection
 
         private static void RegisterPipelineBehaviors(IServiceCollection services, MediatorOptions options)
         {
+            // Sort each behavior list by Order (stable sort preserves registration order for equal values).
+            // OrderBy in LINQ is a stable sort.
+
             // Command behaviors
-            foreach (var behaviorType in options.CommandBehaviors)
+            foreach (var (behaviorType, _) in options.CommandBehaviors.OrderBy(b => b.Order))
             {
                 services.AddTransient(typeof(ICommandPipelineBehavior<,>), behaviorType);
             }
 
             // feature #141 - Register non-returning command pipeline behaviors
-            foreach (var behaviorType in options.VoidCommandBehaviors)
+            foreach (var (behaviorType, _) in options.VoidCommandBehaviors.OrderBy(b => b.Order))
             {
                 services.AddTransient(typeof(ICommandPipelineBehavior<>), behaviorType);
             }
 
             // Query behaviors
-            foreach (var behaviorType in options.QueryBehaviors)
+            foreach (var (behaviorType, _) in options.QueryBehaviors.OrderBy(b => b.Order))
             {
                 if (behaviorType.IsGenericTypeDefinition)
                 {
@@ -150,7 +153,7 @@ namespace Cortex.Mediator.DependencyInjection
             }
 
             // Notification behaviors
-            foreach (var behaviorType in options.NotificationBehaviors)
+            foreach (var (behaviorType, _) in options.NotificationBehaviors.OrderBy(b => b.Order))
             {
                 if (behaviorType.IsGenericTypeDefinition)
                 {
@@ -171,7 +174,7 @@ namespace Cortex.Mediator.DependencyInjection
             }
 
             // Stream query behaviors
-            foreach (var behaviorType in options.StreamQueryBehaviors)
+            foreach (var (behaviorType, _) in options.StreamQueryBehaviors.OrderBy(b => b.Order))
             {
                 services.AddTransient(typeof(IStreamQueryPipelineBehavior<,>), behaviorType);
             }

--- a/src/Cortex.Tests/Mediator/Tests/PipelineBehaviorOrderingTests.cs
+++ b/src/Cortex.Tests/Mediator/Tests/PipelineBehaviorOrderingTests.cs
@@ -1,0 +1,579 @@
+using Cortex.Mediator;
+using Cortex.Mediator.Commands;
+using Cortex.Mediator.DependencyInjection;
+using Cortex.Mediator.Notifications;
+using Cortex.Mediator.Queries;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cortex.Tests.Mediator.Tests
+{
+    #region Test Types for Pipeline Behavior Ordering
+
+    // --- Commands ---
+
+    public class OrderTestCommand : ICommand<string>
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    public class OrderTestCommandHandler : ICommandHandler<OrderTestCommand, string>
+    {
+        private readonly List<string> _log;
+
+        public OrderTestCommandHandler(List<string> log)
+        {
+            _log = log;
+        }
+
+        public Task<string> Handle(OrderTestCommand command, CancellationToken cancellationToken)
+        {
+            _log.Add("Handler");
+            return Task.FromResult(command.Value);
+        }
+    }
+
+    public class OrderTestVoidCommand : ICommand
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    public class OrderTestVoidCommandHandler : ICommandHandler<OrderTestVoidCommand>
+    {
+        private readonly List<string> _log;
+
+        public OrderTestVoidCommandHandler(List<string> log)
+        {
+            _log = log;
+        }
+
+        public Task Handle(OrderTestVoidCommand command, CancellationToken cancellationToken)
+        {
+            _log.Add("Handler");
+            return Task.CompletedTask;
+        }
+    }
+
+    // --- Queries ---
+
+    public class OrderTestQuery : IQuery<string>
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    public class OrderTestQueryHandler : IQueryHandler<OrderTestQuery, string>
+    {
+        private readonly List<string> _log;
+
+        public OrderTestQueryHandler(List<string> log)
+        {
+            _log = log;
+        }
+
+        public Task<string> Handle(OrderTestQuery query, CancellationToken cancellationToken)
+        {
+            _log.Add("Handler");
+            return Task.FromResult(query.Value);
+        }
+    }
+
+    // --- Notifications ---
+
+    public class OrderTestNotification : INotification
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    public class OrderTestNotificationHandler : INotificationHandler<OrderTestNotification>
+    {
+        private readonly List<string> _log;
+
+        public OrderTestNotificationHandler(List<string> log)
+        {
+            _log = log;
+        }
+
+        public Task Handle(OrderTestNotification notification, CancellationToken cancellationToken)
+        {
+            _log.Add("Handler");
+            return Task.CompletedTask;
+        }
+    }
+
+    // --- Command Behaviors (open generic) ---
+
+    public class AlphaCommandBehavior<TCommand, TResult> : ICommandPipelineBehavior<TCommand, TResult>
+        where TCommand : ICommand<TResult>
+    {
+        private readonly List<string> _log;
+
+        public AlphaCommandBehavior(List<string> log) => _log = log;
+
+        public async Task<TResult> Handle(TCommand command, CommandHandlerDelegate<TResult> next, CancellationToken cancellationToken)
+        {
+            _log.Add("Alpha:Before");
+            var result = await next();
+            _log.Add("Alpha:After");
+            return result;
+        }
+    }
+
+    public class BetaCommandBehavior<TCommand, TResult> : ICommandPipelineBehavior<TCommand, TResult>
+        where TCommand : ICommand<TResult>
+    {
+        private readonly List<string> _log;
+
+        public BetaCommandBehavior(List<string> log) => _log = log;
+
+        public async Task<TResult> Handle(TCommand command, CommandHandlerDelegate<TResult> next, CancellationToken cancellationToken)
+        {
+            _log.Add("Beta:Before");
+            var result = await next();
+            _log.Add("Beta:After");
+            return result;
+        }
+    }
+
+    public class GammaCommandBehavior<TCommand, TResult> : ICommandPipelineBehavior<TCommand, TResult>
+        where TCommand : ICommand<TResult>
+    {
+        private readonly List<string> _log;
+
+        public GammaCommandBehavior(List<string> log) => _log = log;
+
+        public async Task<TResult> Handle(TCommand command, CommandHandlerDelegate<TResult> next, CancellationToken cancellationToken)
+        {
+            _log.Add("Gamma:Before");
+            var result = await next();
+            _log.Add("Gamma:After");
+            return result;
+        }
+    }
+
+    // --- Void Command Behaviors (open generic) ---
+
+    public class AlphaVoidCommandBehavior<TCommand> : ICommandPipelineBehavior<TCommand>
+        where TCommand : ICommand
+    {
+        private readonly List<string> _log;
+
+        public AlphaVoidCommandBehavior(List<string> log) => _log = log;
+
+        public async Task Handle(TCommand command, CommandHandlerDelegate next, CancellationToken cancellationToken)
+        {
+            _log.Add("Alpha:Before");
+            await next();
+            _log.Add("Alpha:After");
+        }
+    }
+
+    public class BetaVoidCommandBehavior<TCommand> : ICommandPipelineBehavior<TCommand>
+        where TCommand : ICommand
+    {
+        private readonly List<string> _log;
+
+        public BetaVoidCommandBehavior(List<string> log) => _log = log;
+
+        public async Task Handle(TCommand command, CommandHandlerDelegate next, CancellationToken cancellationToken)
+        {
+            _log.Add("Beta:Before");
+            await next();
+            _log.Add("Beta:After");
+        }
+    }
+
+    // --- Query Behaviors (open generic) ---
+
+    public class AlphaQueryBehavior<TQuery, TResult> : IQueryPipelineBehavior<TQuery, TResult>
+        where TQuery : IQuery<TResult>
+    {
+        private readonly List<string> _log;
+
+        public AlphaQueryBehavior(List<string> log) => _log = log;
+
+        public async Task<TResult> Handle(TQuery query, QueryHandlerDelegate<TResult> next, CancellationToken cancellationToken)
+        {
+            _log.Add("Alpha:Before");
+            var result = await next();
+            _log.Add("Alpha:After");
+            return result;
+        }
+    }
+
+    public class BetaQueryBehavior<TQuery, TResult> : IQueryPipelineBehavior<TQuery, TResult>
+        where TQuery : IQuery<TResult>
+    {
+        private readonly List<string> _log;
+
+        public BetaQueryBehavior(List<string> log) => _log = log;
+
+        public async Task<TResult> Handle(TQuery query, QueryHandlerDelegate<TResult> next, CancellationToken cancellationToken)
+        {
+            _log.Add("Beta:Before");
+            var result = await next();
+            _log.Add("Beta:After");
+            return result;
+        }
+    }
+
+    public class GammaQueryBehavior<TQuery, TResult> : IQueryPipelineBehavior<TQuery, TResult>
+        where TQuery : IQuery<TResult>
+    {
+        private readonly List<string> _log;
+
+        public GammaQueryBehavior(List<string> log) => _log = log;
+
+        public async Task<TResult> Handle(TQuery query, QueryHandlerDelegate<TResult> next, CancellationToken cancellationToken)
+        {
+            _log.Add("Gamma:Before");
+            var result = await next();
+            _log.Add("Gamma:After");
+            return result;
+        }
+    }
+
+    // --- Notification Behaviors (open generic) ---
+
+    public class AlphaNotificationBehavior<TNotification> : INotificationPipelineBehavior<TNotification>
+        where TNotification : INotification
+    {
+        private readonly List<string> _log;
+
+        public AlphaNotificationBehavior(List<string> log) => _log = log;
+
+        public async Task Handle(TNotification notification, NotificationHandlerDelegate next, CancellationToken cancellationToken)
+        {
+            _log.Add("Alpha:Before");
+            await next();
+            _log.Add("Alpha:After");
+        }
+    }
+
+    public class BetaNotificationBehavior<TNotification> : INotificationPipelineBehavior<TNotification>
+        where TNotification : INotification
+    {
+        private readonly List<string> _log;
+
+        public BetaNotificationBehavior(List<string> log) => _log = log;
+
+        public async Task Handle(TNotification notification, NotificationHandlerDelegate next, CancellationToken cancellationToken)
+        {
+            _log.Add("Beta:Before");
+            await next();
+            _log.Add("Beta:After");
+        }
+    }
+
+    #endregion
+
+    public class PipelineBehaviorOrderingTests
+    {
+        #region Command Behavior Ordering Tests
+
+        [Fact]
+        public async Task CommandBehaviors_WithDifferentOrders_ShouldExecuteInOrderAscending()
+        {
+            // Arrange: Register Beta at order 2, then Alpha at order 1.
+            // Despite Beta being registered first, Alpha (order=1) should execute first (outermost).
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton(log);
+            services.AddCortexMediator(new Type[0], options =>
+            {
+                options.AddOpenCommandPipelineBehavior(typeof(BetaCommandBehavior<,>), order: 2);
+                options.AddOpenCommandPipelineBehavior(typeof(AlphaCommandBehavior<,>), order: 1);
+            });
+            services.AddTransient<ICommandHandler<OrderTestCommand, string>>(sp =>
+                new OrderTestCommandHandler(sp.GetRequiredService<List<string>>()));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.SendCommandAsync<OrderTestCommand, string>(new OrderTestCommand { Value = "test" });
+
+            // Assert: Alpha (order=1) wraps Beta (order=2) wraps Handler
+            Assert.Equal(new[] { "Alpha:Before", "Beta:Before", "Handler", "Beta:After", "Alpha:After" }, log);
+        }
+
+        [Fact]
+        public async Task CommandBehaviors_WithSameOrder_ShouldPreserveRegistrationOrder()
+        {
+            // Arrange: Register Alpha then Beta, both at default order 0.
+            // Registration order should be preserved.
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton(log);
+            services.AddCortexMediator(new Type[0], options =>
+            {
+                options.AddOpenCommandPipelineBehavior(typeof(AlphaCommandBehavior<,>));
+                options.AddOpenCommandPipelineBehavior(typeof(BetaCommandBehavior<,>));
+            });
+            services.AddTransient<ICommandHandler<OrderTestCommand, string>>(sp =>
+                new OrderTestCommandHandler(sp.GetRequiredService<List<string>>()));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.SendCommandAsync<OrderTestCommand, string>(new OrderTestCommand { Value = "test" });
+
+            // Assert: Alpha registered first, so Alpha is outermost
+            Assert.Equal(new[] { "Alpha:Before", "Beta:Before", "Handler", "Beta:After", "Alpha:After" }, log);
+        }
+
+        [Fact]
+        public async Task CommandBehaviors_ThreeBehaviors_ShouldRespectOrderFully()
+        {
+            // Arrange: Register in order Gamma(3), Alpha(1), Beta(2)
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton(log);
+            services.AddCortexMediator(new Type[0], options =>
+            {
+                options.AddOpenCommandPipelineBehavior(typeof(GammaCommandBehavior<,>), order: 3);
+                options.AddOpenCommandPipelineBehavior(typeof(AlphaCommandBehavior<,>), order: 1);
+                options.AddOpenCommandPipelineBehavior(typeof(BetaCommandBehavior<,>), order: 2);
+            });
+            services.AddTransient<ICommandHandler<OrderTestCommand, string>>(sp =>
+                new OrderTestCommandHandler(sp.GetRequiredService<List<string>>()));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.SendCommandAsync<OrderTestCommand, string>(new OrderTestCommand { Value = "test" });
+
+            // Assert: Alpha(1) → Beta(2) → Gamma(3) → Handler
+            Assert.Equal(new[]
+            {
+                "Alpha:Before", "Beta:Before", "Gamma:Before",
+                "Handler",
+                "Gamma:After", "Beta:After", "Alpha:After"
+            }, log);
+        }
+
+        [Fact]
+        public async Task CommandBehaviors_NegativeOrder_ShouldExecuteBeforeZero()
+        {
+            // Arrange: Beta at default order 0, Alpha at order -1
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton(log);
+            services.AddCortexMediator(new Type[0], options =>
+            {
+                options.AddOpenCommandPipelineBehavior(typeof(BetaCommandBehavior<,>));
+                options.AddOpenCommandPipelineBehavior(typeof(AlphaCommandBehavior<,>), order: -1);
+            });
+            services.AddTransient<ICommandHandler<OrderTestCommand, string>>(sp =>
+                new OrderTestCommandHandler(sp.GetRequiredService<List<string>>()));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.SendCommandAsync<OrderTestCommand, string>(new OrderTestCommand { Value = "test" });
+
+            // Assert: Alpha(order=-1) runs before Beta(order=0)
+            Assert.Equal(new[] { "Alpha:Before", "Beta:Before", "Handler", "Beta:After", "Alpha:After" }, log);
+        }
+
+        #endregion
+
+        #region Void Command Behavior Ordering Tests
+
+        [Fact]
+        public async Task VoidCommandBehaviors_WithDifferentOrders_ShouldExecuteInOrderAscending()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton(log);
+            services.AddCortexMediator(new Type[0], options =>
+            {
+                options.AddOpenCommandPipelineBehavior(typeof(BetaVoidCommandBehavior<>), order: 2);
+                options.AddOpenCommandPipelineBehavior(typeof(AlphaVoidCommandBehavior<>), order: 1);
+            });
+            services.AddTransient<ICommandHandler<OrderTestVoidCommand>>(sp =>
+                new OrderTestVoidCommandHandler(sp.GetRequiredService<List<string>>()));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.SendCommandAsync(new OrderTestVoidCommand { Value = "test" });
+
+            // Assert
+            Assert.Equal(new[] { "Alpha:Before", "Beta:Before", "Handler", "Beta:After", "Alpha:After" }, log);
+        }
+
+        #endregion
+
+        #region Query Behavior Ordering Tests
+
+        [Fact]
+        public async Task QueryBehaviors_WithDifferentOrders_ShouldExecuteInOrderAscending()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton(log);
+            services.AddCortexMediator(new Type[0], options =>
+            {
+                options.AddOpenQueryPipelineBehavior(typeof(BetaQueryBehavior<,>), order: 2);
+                options.AddOpenQueryPipelineBehavior(typeof(AlphaQueryBehavior<,>), order: 1);
+            });
+            services.AddTransient<IQueryHandler<OrderTestQuery, string>>(sp =>
+                new OrderTestQueryHandler(sp.GetRequiredService<List<string>>()));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.SendQueryAsync<OrderTestQuery, string>(new OrderTestQuery { Value = "test" });
+
+            // Assert
+            Assert.Equal(new[] { "Alpha:Before", "Beta:Before", "Handler", "Beta:After", "Alpha:After" }, log);
+        }
+
+        [Fact]
+        public async Task QueryBehaviors_ThreeBehaviors_ShouldRespectOrderFully()
+        {
+            // Arrange: Register in scrambled order
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton(log);
+            services.AddCortexMediator(new Type[0], options =>
+            {
+                options.AddOpenQueryPipelineBehavior(typeof(GammaQueryBehavior<,>), order: 3);
+                options.AddOpenQueryPipelineBehavior(typeof(AlphaQueryBehavior<,>), order: 1);
+                options.AddOpenQueryPipelineBehavior(typeof(BetaQueryBehavior<,>), order: 2);
+            });
+            services.AddTransient<IQueryHandler<OrderTestQuery, string>>(sp =>
+                new OrderTestQueryHandler(sp.GetRequiredService<List<string>>()));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.SendQueryAsync<OrderTestQuery, string>(new OrderTestQuery { Value = "test" });
+
+            // Assert
+            Assert.Equal(new[]
+            {
+                "Alpha:Before", "Beta:Before", "Gamma:Before",
+                "Handler",
+                "Gamma:After", "Beta:After", "Alpha:After"
+            }, log);
+        }
+
+        #endregion
+
+        #region Notification Behavior Ordering Tests
+
+        [Fact]
+        public async Task NotificationBehaviors_WithDifferentOrders_ShouldExecuteInOrderAscending()
+        {
+            // Arrange
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton(log);
+            services.AddCortexMediator(new Type[0], options =>
+            {
+                options.UseNotificationPublishStrategy<SequentialNotificationStrategy>();
+                options.AddOpenNotificationPipelineBehavior(typeof(BetaNotificationBehavior<>), order: 2);
+                options.AddOpenNotificationPipelineBehavior(typeof(AlphaNotificationBehavior<>), order: 1);
+            });
+            services.AddTransient<INotificationHandler<OrderTestNotification>>(sp =>
+                new OrderTestNotificationHandler(sp.GetRequiredService<List<string>>()));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.PublishAsync(new OrderTestNotification { Value = "test" });
+
+            // Assert
+            Assert.Equal(new[] { "Alpha:Before", "Beta:Before", "Handler", "Beta:After", "Alpha:After" }, log);
+        }
+
+        #endregion
+
+        #region Default Order Backward Compatibility Tests
+
+        [Fact]
+        public async Task DefaultOrder_WithoutExplicitOrder_ShouldPreserveRegistrationOrder()
+        {
+            // Arrange: All behaviors registered at default order (0). Should preserve registration order.
+            var log = new List<string>();
+            var services = new ServiceCollection();
+            services.AddSingleton(log);
+            services.AddCortexMediator(new Type[0], options =>
+            {
+                options.AddOpenCommandPipelineBehavior(typeof(AlphaCommandBehavior<,>));
+                options.AddOpenCommandPipelineBehavior(typeof(BetaCommandBehavior<,>));
+                options.AddOpenCommandPipelineBehavior(typeof(GammaCommandBehavior<,>));
+            });
+            services.AddTransient<ICommandHandler<OrderTestCommand, string>>(sp =>
+                new OrderTestCommandHandler(sp.GetRequiredService<List<string>>()));
+
+            var provider = services.BuildServiceProvider();
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            await mediator.SendCommandAsync<OrderTestCommand, string>(new OrderTestCommand { Value = "test" });
+
+            // Assert: Registration order preserved (Alpha, Beta, Gamma)
+            Assert.Equal(new[]
+            {
+                "Alpha:Before", "Beta:Before", "Gamma:Before",
+                "Handler",
+                "Gamma:After", "Beta:After", "Alpha:After"
+            }, log);
+        }
+
+        #endregion
+
+        #region Fluent API Tests
+
+        [Fact]
+        public void AddOpenCommandPipelineBehavior_WithOrder_ShouldReturnOptionsForFluent()
+        {
+            // Arrange
+            var options = new MediatorOptions();
+
+            // Act
+            var result = options.AddOpenCommandPipelineBehavior(typeof(AlphaCommandBehavior<,>), order: 5);
+
+            // Assert
+            Assert.Same(options, result);
+        }
+
+        [Fact]
+        public void AddOpenQueryPipelineBehavior_WithOrder_ShouldReturnOptionsForFluent()
+        {
+            // Arrange
+            var options = new MediatorOptions();
+
+            // Act
+            var result = options.AddOpenQueryPipelineBehavior(typeof(AlphaQueryBehavior<,>), order: 3);
+
+            // Assert
+            Assert.Same(options, result);
+        }
+
+        [Fact]
+        public void AddOpenNotificationPipelineBehavior_WithOrder_ShouldReturnOptionsForFluent()
+        {
+            // Arrange
+            var options = new MediatorOptions();
+
+            // Act
+            var result = options.AddOpenNotificationPipelineBehavior(typeof(AlphaNotificationBehavior<>), order: 10);
+
+            // Assert
+            Assert.Same(options, result);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Adds support for specifying execution order of command, query, and notification pipeline behaviors via an optional order parameter in MediatorOptions. Behaviors are now registered and executed in ascending order, with registration order preserved for equal values. Includes comprehensive tests for ordering logic and ensures full backward compatibility. This enables precise control over pipeline execution, supporting advanced scenarios such as prioritized logging, validation, or caching behaviors.

Changes Made

  src/Cortex.Mediator/DependencyInjection/MediatorOptions.cs
  - Internal behavior lists changed from List<Type> to List<(Type BehaviorType, int Order)>
  - All 7 registration methods now accept an optional int order = 0 parameter:
    - AddCommandPipelineBehavior<T>(int order = 0)
    - AddOpenCommandPipelineBehavior(Type, int order = 0)
    - AddQueryPipelineBehavior<T>(int order = 0)
    - AddOpenQueryPipelineBehavior(Type, int order = 0)
    - AddNotificationPipelineBehavior<T>(int order = 0)
    - AddOpenNotificationPipelineBehavior(Type, int order = 0)
    - AddOpenStreamQueryPipelineBehavior(Type, int order = 0)

  src/Cortex.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
  - RegisterPipelineBehaviors now sorts each behavior list by Order (ascending, stable) using LINQ OrderBy before registering with DI

  src/Cortex.Tests/Mediator/Tests/PipelineBehaviorOrderingTests.cs (new)
  - 12 tests covering command, void command, query, and notification behavior ordering
  - Tests verify: different orders, same order (registration order preserved), three behaviors, negative orders, backward compatibility (default order=0), fluent API

  Key Design Decisions

  - Lower order = runs first (outermost in pipeline)
  - Default order is 0 — fully backward compatible
  - Stable sort — behaviors with the same order preserve their registration order
  - Negative orders supported — allows inserting behaviors before the default

  Test Results

  - All 12 new tests pass
  - All 226 mediator tests pass (zero regressions)
  - 3 pre-existing failures in Streams tests (timing-sensitive, unrelated)